### PR TITLE
.gitattributes to make the dist package smaller

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+/tests export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.travis.yml export-ignore
+/build.xml export-ignore
+/phpdoc.xml export-ignore


### PR DESCRIPTION
Hi! 👋 

With the latest version we've encountered this problem:

```
Updating zbateson/mail-mime-parser (1.1.3 => 1.1.4): Downloading (100%)    Failed to execute unzip -qq  '/Users/ondrei/www/slevomat/vendor/zbateson/mail-mime-parser/bf90064552864e0da4f563d6fce5eea0' -d '/Users/ondrei/www/slevomat/vendor/composer/cce42838'

error:  cannot create /Users/ondrei/www/slevomat/vendor/composer/cce42838/zbateson-mail-mime-parser-051a3cb/tests/_data/emails/files/Biodiversit+� de semaine en semaine.doc
       Illegal byte sequence

   The archive may contain identical file names with different capitalization (which fails on case insensitive filesystems)
   Unzip with unzip command failed, falling back to ZipArchive class
```

Probably because of some weird unicode sequence. Anyway, the tests should be missing from the final distribution package. You can achieve that with a `.gitattributes` file. Read more about it here: https://madewithlove.be/gitattributes/

I've attached a proposed .gitattributes file - feel free to create your own. Thanks!