### PR TITLE
Rewritten regex to fix PHP7.3 bug in preg_split()

### DIFF
--- a/src/Header/Consumer/Received/GenericReceivedConsumer.php
+++ b/src/Header/Consumer/Received/GenericReceivedConsumer.php
@@ -123,7 +123,7 @@ class GenericReceivedConsumer extends GenericConsumer
     {
         return [
             '\s+',
-            '[\A\s]*(?i)' . preg_quote($this->getPartName(), '/') . '(?-i)\s+'
+            '(\A)?\s*(?i)' . preg_quote($this->getPartName(), '/') . '(?-i)\s+'
         ];
     }
 


### PR DESCRIPTION
Since `\A` cannot be repeated, it cannot be contained in a group which characters can be repeated.