### PR TITLE
Added getDateTimeImmutable()

### DIFF
--- a/src/Header/DateHeader.php
+++ b/src/Header/DateHeader.php
@@ -39,4 +39,13 @@ class DateHeader extends AbstractHeader
         }
         return null;
     }
+    
+    public function getDateTimeImmutable()
+    {
+        $dateTime = $this->getDateTime();
+        if ($dateTime instanceof \DateTime) {
+            return \DateTimeImmutable::createFromMutable($dateTime);
+        }
+        return null;
+    }
 }


### PR DESCRIPTION
Just a convenience method - useful, when you save this to a `datetime_immutable` database field (i.e. the setter expects `\DateTimeImmutable`)