### PR TITLE
Php unit upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 vendor
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,11 @@ language: php
 dist: trusty
 
 php:
-    - 5.4
-    - 5.5
-    - 5.6
-    - 7.0
     - 7.1
     - 7.2
     - 7.3
     - 7.4
+    - 8.0
     - nightly
 matrix:
     allow_failures:

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "zbateson/stream-decorators": "^1.0.4"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8 || ^5.7 || ^6.5 || ^7.5",
+        "phpunit/phpunit": ">=4.8",
         "phing/phing": "^2.15.0",
         "phpdocumentor/phpdocumentor": "^2.9.0",
         "jms/serializer": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6943d08e979da0a087361db50c52c76c",
+    "content-hash": "8bae3ca920747ad92bced4a0e5882e0d",
     "packages": [
         {
             "name": "guzzlehttp/psr7",
@@ -169,20 +169,20 @@
         },
         {
             "name": "symfony/polyfill-iconv",
-            "version": "v1.18.1",
+            "version": "v1.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-iconv.git",
-                "reference": "6c2f78eb8f5ab8eaea98f6d414a5915f2e0fce36"
+                "reference": "c536646fdb4f29104dd26effc2fdcb9a5b085024"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-iconv/zipball/6c2f78eb8f5ab8eaea98f6d414a5915f2e0fce36",
-                "reference": "6c2f78eb8f5ab8eaea98f6d414a5915f2e0fce36",
+                "url": "https://api.github.com/repos/symfony/polyfill-iconv/zipball/c536646fdb4f29104dd26effc2fdcb9a5b085024",
+                "reference": "c536646fdb4f29104dd26effc2fdcb9a5b085024",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.1"
             },
             "suggest": {
                 "ext-iconv": "For best performance"
@@ -190,7 +190,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.18-dev"
+                    "dev-main": "1.20-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -242,24 +242,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-07-14T12:35:20+00:00"
+            "time": "2020-10-23T14:02:19+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.18.1",
+            "version": "v1.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "a6977d63bf9a0ad4c65cd352709e230876f9904a"
+                "reference": "39d483bdf39be819deabf04ec872eb0b2410b531"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/a6977d63bf9a0ad4c65cd352709e230876f9904a",
-                "reference": "a6977d63bf9a0ad4c65cd352709e230876f9904a",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/39d483bdf39be819deabf04ec872eb0b2410b531",
+                "reference": "39d483bdf39be819deabf04ec872eb0b2410b531",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.1"
             },
             "suggest": {
                 "ext-mbstring": "For best performance"
@@ -267,7 +267,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.18-dev"
+                    "dev-main": "1.20-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -319,7 +319,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-07-14T12:35:20+00:00"
+            "time": "2020-10-23T14:02:19+00:00"
         },
         {
             "name": "zbateson/mb-wrapper",
@@ -665,16 +665,16 @@
         },
         {
             "name": "doctrine/annotations",
-            "version": "1.10.4",
+            "version": "1.11.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/annotations.git",
-                "reference": "bfe91e31984e2ba76df1c1339681770401ec262f"
+                "reference": "ce77a7ba1770462cd705a91a151b6c3746f9c6ad"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/annotations/zipball/bfe91e31984e2ba76df1c1339681770401ec262f",
-                "reference": "bfe91e31984e2ba76df1c1339681770401ec262f",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/ce77a7ba1770462cd705a91a151b6c3746f9c6ad",
+                "reference": "ce77a7ba1770462cd705a91a151b6c3746f9c6ad",
                 "shasum": ""
             },
             "require": {
@@ -684,13 +684,14 @@
             },
             "require-dev": {
                 "doctrine/cache": "1.*",
+                "doctrine/coding-standard": "^6.0 || ^8.1",
                 "phpstan/phpstan": "^0.12.20",
                 "phpunit/phpunit": "^7.5 || ^9.1.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.9.x-dev"
+                    "dev-master": "1.11.x-dev"
                 }
             },
             "autoload": {
@@ -725,46 +726,41 @@
                 }
             ],
             "description": "Docblock Annotations Parser",
-            "homepage": "http://www.doctrine-project.org",
+            "homepage": "https://www.doctrine-project.org/projects/annotations.html",
             "keywords": [
                 "annotations",
                 "docblock",
                 "parser"
             ],
-            "time": "2020-08-10T19:35:50+00:00"
+            "time": "2020-10-26T10:28:16+00:00"
         },
         {
             "name": "doctrine/instantiator",
-            "version": "1.3.1",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "f350df0268e904597e3bd9c4685c53e0e333feea"
+                "reference": "d56bf6102915de5702778fe20f2de3b2fe570b5b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/f350df0268e904597e3bd9c4685c53e0e333feea",
-                "reference": "f350df0268e904597e3bd9c4685c53e0e333feea",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/d56bf6102915de5702778fe20f2de3b2fe570b5b",
+                "reference": "d56bf6102915de5702778fe20f2de3b2fe570b5b",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^6.0",
+                "doctrine/coding-standard": "^8.0",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpbench/phpbench": "^0.13",
-                "phpstan/phpstan-phpunit": "^0.11",
-                "phpstan/phpstan-shim": "^0.11",
-                "phpunit/phpunit": "^7.0"
+                "phpbench/phpbench": "^0.13 || 1.0.0-alpha2",
+                "phpstan/phpstan": "^0.12",
+                "phpstan/phpstan-phpunit": "^0.12",
+                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.2.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
@@ -778,7 +774,7 @@
                 {
                     "name": "Marco Pivetta",
                     "email": "ocramius@gmail.com",
-                    "homepage": "http://ocramius.github.com/"
+                    "homepage": "https://ocramius.github.io/"
                 }
             ],
             "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
@@ -801,7 +797,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-05-29T17:27:14+00:00"
+            "time": "2020-11-10T18:47:58+00:00"
         },
         {
             "name": "doctrine/lexer",
@@ -1229,16 +1225,16 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.10.1",
+            "version": "1.10.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "969b211f9a51aa1f6c01d1d2aef56d3bd91598e5"
+                "reference": "776f831124e9c62e1a2c601ecc52e776d8bb7220"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/969b211f9a51aa1f6c01d1d2aef56d3bd91598e5",
-                "reference": "969b211f9a51aa1f6c01d1d2aef56d3bd91598e5",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/776f831124e9c62e1a2c601ecc52e776d8bb7220",
+                "reference": "776f831124e9c62e1a2c601ecc52e776d8bb7220",
                 "shasum": ""
             },
             "require": {
@@ -1279,7 +1275,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-06-29T13:22:24+00:00"
+            "time": "2020-11-13T09:40:50+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -1450,28 +1446,29 @@
         },
         {
             "name": "phar-io/manifest",
-            "version": "1.0.3",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/manifest.git",
-                "reference": "7761fcacf03b4d4f16e7ccb606d4879ca431fcf4"
+                "reference": "85265efd3af7ba3ca4b2a2c34dbfc5788dd29133"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/manifest/zipball/7761fcacf03b4d4f16e7ccb606d4879ca431fcf4",
-                "reference": "7761fcacf03b4d4f16e7ccb606d4879ca431fcf4",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/85265efd3af7ba3ca4b2a2c34dbfc5788dd29133",
+                "reference": "85265efd3af7ba3ca4b2a2c34dbfc5788dd29133",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-phar": "*",
-                "phar-io/version": "^2.0",
-                "php": "^5.6 || ^7.0"
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -1501,24 +1498,24 @@
                 }
             ],
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
-            "time": "2018-07-08T19:23:20+00:00"
+            "time": "2020-06-27T14:33:11+00:00"
         },
         {
             "name": "phar-io/version",
-            "version": "2.0.1",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/version.git",
-                "reference": "45a2ec53a73c70ce41d55cedef9063630abaf1b6"
+                "reference": "726c026815142e4f8677b7cb7f2249c9ffb7ecae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/version/zipball/45a2ec53a73c70ce41d55cedef9063630abaf1b6",
-                "reference": "45a2ec53a73c70ce41d55cedef9063630abaf1b6",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/726c026815142e4f8677b7cb7f2249c9ffb7ecae",
+                "reference": "726c026815142e4f8677b7cb7f2249c9ffb7ecae",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": "^7.2 || ^8.0"
             },
             "type": "library",
             "autoload": {
@@ -1548,7 +1545,7 @@
                 }
             ],
             "description": "Library for handling version information and constraints",
-            "time": "2018-07-08T19:19:57+00:00"
+            "time": "2020-11-30T09:21:21+00:00"
         },
         {
             "name": "phing/phing",
@@ -2098,40 +2095,40 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "6.1.4",
+            "version": "7.0.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "807e6013b00af69b6c5d9ceb4282d0393dbb9d8d"
+                "reference": "ad0dcd7b184e76f7198a1fe07685bfbec3ae911a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/807e6013b00af69b6c5d9ceb4282d0393dbb9d8d",
-                "reference": "807e6013b00af69b6c5d9ceb4282d0393dbb9d8d",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/ad0dcd7b184e76f7198a1fe07685bfbec3ae911a",
+                "reference": "ad0dcd7b184e76f7198a1fe07685bfbec3ae911a",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-xmlwriter": "*",
-                "php": "^7.1",
-                "phpunit/php-file-iterator": "^2.0",
+                "php": ">=7.2",
+                "phpunit/php-file-iterator": "^2.0.2",
                 "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-token-stream": "^3.0",
+                "phpunit/php-token-stream": "^3.1.1",
                 "sebastian/code-unit-reverse-lookup": "^1.0.1",
-                "sebastian/environment": "^3.1 || ^4.0",
+                "sebastian/environment": "^4.2.2",
                 "sebastian/version": "^2.0.1",
-                "theseer/tokenizer": "^1.1"
+                "theseer/tokenizer": "^1.1.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.0"
+                "phpunit/phpunit": "^8.2.2"
             },
             "suggest": {
-                "ext-xdebug": "^2.6.0"
+                "ext-xdebug": "^2.7.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.1-dev"
+                    "dev-master": "7.0-dev"
                 }
             },
             "autoload": {
@@ -2157,27 +2154,33 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-10-31T16:06:48+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T08:35:22+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "2.0.2",
+            "version": "2.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "050bedf145a257b1ff02746c31894800e5122946"
+                "reference": "4b49fb70f067272b659ef0174ff9ca40fdaa6357"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/050bedf145a257b1ff02746c31894800e5122946",
-                "reference": "050bedf145a257b1ff02746c31894800e5122946",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/4b49fb70f067272b659ef0174ff9ca40fdaa6357",
+                "reference": "4b49fb70f067272b659ef0174ff9ca40fdaa6357",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1"
+                "php": ">=7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.1"
+                "phpunit/phpunit": "^8.5"
             },
             "type": "library",
             "extra": {
@@ -2207,7 +2210,13 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2018-09-13T20:33:42+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T08:25:21+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -2252,23 +2261,23 @@
         },
         {
             "name": "phpunit/php-timer",
-            "version": "2.1.2",
+            "version": "2.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "1038454804406b0b5f5f520358e78c1c2f71501e"
+                "reference": "2454ae1765516d20c4ffe103d85a58a9a3bd5662"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/1038454804406b0b5f5f520358e78c1c2f71501e",
-                "reference": "1038454804406b0b5f5f520358e78c1c2f71501e",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/2454ae1765516d20c4ffe103d85a58a9a3bd5662",
+                "reference": "2454ae1765516d20c4ffe103d85a58a9a3bd5662",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1"
+                "php": ">=7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.0"
+                "phpunit/phpunit": "^8.5"
             },
             "type": "library",
             "extra": {
@@ -2297,25 +2306,31 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2019-06-07T04:22:29+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T08:20:02+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "3.1.1",
+            "version": "3.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "995192df77f63a59e47f025390d2d1fdf8f425ff"
+                "reference": "472b687829041c24b25f475e14c2f38a09edf1c2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/995192df77f63a59e47f025390d2d1fdf8f425ff",
-                "reference": "995192df77f63a59e47f025390d2d1fdf8f425ff",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/472b687829041c24b25f475e14c2f38a09edf1c2",
+                "reference": "472b687829041c24b25f475e14c2f38a09edf1c2",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "php": "^7.1"
+                "php": ">=7.1"
             },
             "require-dev": {
                 "phpunit/phpunit": "^7.0"
@@ -2346,50 +2361,55 @@
             "keywords": [
                 "tokenizer"
             ],
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
             "abandoned": true,
-            "time": "2019-09-17T06:23:10+00:00"
+            "time": "2020-11-30T08:38:46+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "7.5.20",
+            "version": "8.5.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "9467db479d1b0487c99733bb1e7944d32deded2c"
+                "reference": "8e86be391a58104ef86037ba8a846524528d784e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/9467db479d1b0487c99733bb1e7944d32deded2c",
-                "reference": "9467db479d1b0487c99733bb1e7944d32deded2c",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/8e86be391a58104ef86037ba8a846524528d784e",
+                "reference": "8e86be391a58104ef86037ba8a846524528d784e",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.1",
+                "doctrine/instantiator": "^1.3.1",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
-                "myclabs/deep-copy": "^1.7",
-                "phar-io/manifest": "^1.0.2",
-                "phar-io/version": "^2.0",
-                "php": "^7.1",
-                "phpspec/prophecy": "^1.7",
-                "phpunit/php-code-coverage": "^6.0.7",
-                "phpunit/php-file-iterator": "^2.0.1",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.10.0",
+                "phar-io/manifest": "^2.0.1",
+                "phar-io/version": "^3.0.2",
+                "php": ">=7.2",
+                "phpspec/prophecy": "^1.10.3",
+                "phpunit/php-code-coverage": "^7.0.12",
+                "phpunit/php-file-iterator": "^2.0.2",
                 "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-timer": "^2.1",
-                "sebastian/comparator": "^3.0",
-                "sebastian/diff": "^3.0",
-                "sebastian/environment": "^4.0",
-                "sebastian/exporter": "^3.1",
-                "sebastian/global-state": "^2.0",
+                "phpunit/php-timer": "^2.1.2",
+                "sebastian/comparator": "^3.0.2",
+                "sebastian/diff": "^3.0.2",
+                "sebastian/environment": "^4.2.3",
+                "sebastian/exporter": "^3.1.2",
+                "sebastian/global-state": "^3.0.0",
                 "sebastian/object-enumerator": "^3.0.3",
-                "sebastian/resource-operations": "^2.0",
+                "sebastian/resource-operations": "^2.0.1",
+                "sebastian/type": "^1.1.3",
                 "sebastian/version": "^2.0.1"
-            },
-            "conflict": {
-                "phpunit/phpunit-mock-objects": "*"
             },
             "require-dev": {
                 "ext-pdo": "*"
@@ -2397,7 +2417,7 @@
             "suggest": {
                 "ext-soap": "*",
                 "ext-xdebug": "*",
-                "phpunit/php-invoker": "^2.0"
+                "phpunit/php-invoker": "^2.0.0"
             },
             "bin": [
                 "phpunit"
@@ -2405,7 +2425,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "7.5-dev"
+                    "dev-master": "8.5-dev"
                 }
             },
             "autoload": {
@@ -2431,7 +2451,17 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2020-01-08T08:45:45+00:00"
+            "funding": [
+                {
+                    "url": "https://phpunit.de/donate.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-12-01T04:53:52+00:00"
         },
         {
             "name": "pimple/pimple",
@@ -2671,23 +2701,23 @@
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
-            "version": "1.0.1",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18"
+                "reference": "1de8cd5c010cb153fcd68b8d0f64606f523f7619"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
-                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/1de8cd5c010cb153fcd68b8d0f64606f523f7619",
+                "reference": "1de8cd5c010cb153fcd68b8d0f64606f523f7619",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": ">=5.6"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.7 || ^6.0"
+                "phpunit/phpunit": "^8.5"
             },
             "type": "library",
             "extra": {
@@ -2712,29 +2742,35 @@
             ],
             "description": "Looks up which function or method a line of code belongs to",
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
-            "time": "2017-03-04T06:30:41+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T08:15:22+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "3.0.2",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "5de4fc177adf9bce8df98d8d141a7559d7ccf6da"
+                "reference": "1071dfcef776a57013124ff35e1fc41ccd294758"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/5de4fc177adf9bce8df98d8d141a7559d7ccf6da",
-                "reference": "5de4fc177adf9bce8df98d8d141a7559d7ccf6da",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/1071dfcef776a57013124ff35e1fc41ccd294758",
+                "reference": "1071dfcef776a57013124ff35e1fc41ccd294758",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1",
+                "php": ">=7.1",
                 "sebastian/diff": "^3.0",
                 "sebastian/exporter": "^3.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.1"
+                "phpunit/phpunit": "^8.5"
             },
             "type": "library",
             "extra": {
@@ -2753,6 +2789,10 @@
             ],
             "authors": [
                 {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
                     "name": "Jeff Welch",
                     "email": "whatthejeff@gmail.com"
                 },
@@ -2763,10 +2803,6 @@
                 {
                     "name": "Bernhard Schussek",
                     "email": "bschussek@2bepublished.at"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
                 }
             ],
             "description": "Provides the functionality to compare PHP values for equality",
@@ -2776,24 +2812,30 @@
                 "compare",
                 "equality"
             ],
-            "time": "2018-07-12T15:12:46+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T08:04:30+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "3.0.2",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "720fcc7e9b5cf384ea68d9d930d480907a0c1a29"
+                "reference": "14f72dd46eaf2f2293cbe79c93cc0bc43161a211"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/720fcc7e9b5cf384ea68d9d930d480907a0c1a29",
-                "reference": "720fcc7e9b5cf384ea68d9d930d480907a0c1a29",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/14f72dd46eaf2f2293cbe79c93cc0bc43161a211",
+                "reference": "14f72dd46eaf2f2293cbe79c93cc0bc43161a211",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1"
+                "php": ">=7.1"
             },
             "require-dev": {
                 "phpunit/phpunit": "^7.5 || ^8.0",
@@ -2816,12 +2858,12 @@
             ],
             "authors": [
                 {
-                    "name": "Kore Nordmann",
-                    "email": "mail@kore-nordmann.de"
-                },
-                {
                     "name": "Sebastian Bergmann",
                     "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
                 }
             ],
             "description": "Diff implementation",
@@ -2832,24 +2874,30 @@
                 "unidiff",
                 "unified diff"
             ],
-            "time": "2019-02-04T06:01:07+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T07:59:04+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "4.2.3",
+            "version": "4.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "464c90d7bdf5ad4e8a6aea15c091fec0603d4368"
+                "reference": "d47bbbad83711771f167c72d4e3f25f7fcc1f8b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/464c90d7bdf5ad4e8a6aea15c091fec0603d4368",
-                "reference": "464c90d7bdf5ad4e8a6aea15c091fec0603d4368",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/d47bbbad83711771f167c72d4e3f25f7fcc1f8b0",
+                "reference": "d47bbbad83711771f167c72d4e3f25f7fcc1f8b0",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1"
+                "php": ">=7.1"
             },
             "require-dev": {
                 "phpunit/phpunit": "^7.5"
@@ -2885,24 +2933,30 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2019-11-20T08:46:58+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T07:53:42+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "3.1.2",
+            "version": "3.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "68609e1261d215ea5b21b7987539cbfbe156ec3e"
+                "reference": "6b853149eab67d4da22291d36f5b0631c0fd856e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/68609e1261d215ea5b21b7987539cbfbe156ec3e",
-                "reference": "68609e1261d215ea5b21b7987539cbfbe156ec3e",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/6b853149eab67d4da22291d36f5b0631c0fd856e",
+                "reference": "6b853149eab67d4da22291d36f5b0631c0fd856e",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0",
+                "php": ">=7.0",
                 "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
@@ -2952,27 +3006,36 @@
                 "export",
                 "exporter"
             ],
-            "time": "2019-09-14T09:02:43+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T07:47:53+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "2.0.0",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4"
+                "reference": "474fb9edb7ab891665d3bfc6317f42a0a150454b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
-                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/474fb9edb7ab891665d3bfc6317f42a0a150454b",
+                "reference": "474fb9edb7ab891665d3bfc6317f42a0a150454b",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": ">=7.2",
+                "sebastian/object-reflector": "^1.1.1",
+                "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "ext-dom": "*",
+                "phpunit/phpunit": "^8.0"
             },
             "suggest": {
                 "ext-uopz": "*"
@@ -2980,7 +3043,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -3003,24 +3066,30 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2017-04-27T15:39:26+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T07:43:24+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "3.0.3",
+            "version": "3.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5"
+                "reference": "e67f6d32ebd0c749cf9d1dbd9f226c727043cdf2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/7cfd9e65d11ffb5af41198476395774d4c8a84c5",
-                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/e67f6d32ebd0c749cf9d1dbd9f226c727043cdf2",
+                "reference": "e67f6d32ebd0c749cf9d1dbd9f226c727043cdf2",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0",
+                "php": ">=7.0",
                 "sebastian/object-reflector": "^1.1.1",
                 "sebastian/recursion-context": "^3.0"
             },
@@ -3050,24 +3119,30 @@
             ],
             "description": "Traverses array structures and object graphs to enumerate all referenced objects",
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
-            "time": "2017-08-03T12:35:26+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T07:40:27+00:00"
         },
         {
             "name": "sebastian/object-reflector",
-            "version": "1.1.1",
+            "version": "1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "773f97c67f28de00d397be301821b06708fca0be"
+                "reference": "9b8772b9cbd456ab45d4a598d2dd1a1bced6363d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/773f97c67f28de00d397be301821b06708fca0be",
-                "reference": "773f97c67f28de00d397be301821b06708fca0be",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/9b8772b9cbd456ab45d4a598d2dd1a1bced6363d",
+                "reference": "9b8772b9cbd456ab45d4a598d2dd1a1bced6363d",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": ">=7.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "^6.0"
@@ -3095,24 +3170,30 @@
             ],
             "description": "Allows reflection of object attributes, including inherited and non-public ones",
             "homepage": "https://github.com/sebastianbergmann/object-reflector/",
-            "time": "2017-03-29T09:07:27+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T07:37:18+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "3.0.0",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8"
+                "reference": "367dcba38d6e1977be014dc4b22f47a484dac7fb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
-                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/367dcba38d6e1977be014dc4b22f47a484dac7fb",
+                "reference": "367dcba38d6e1977be014dc4b22f47a484dac7fb",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": ">=7.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "^6.0"
@@ -3134,12 +3215,12 @@
             ],
             "authors": [
                 {
-                    "name": "Jeff Welch",
-                    "email": "whatthejeff@gmail.com"
-                },
-                {
                     "name": "Sebastian Bergmann",
                     "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
                 },
                 {
                     "name": "Adam Harvey",
@@ -3148,24 +3229,30 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2017-03-03T06:23:57+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T07:34:24+00:00"
         },
         {
             "name": "sebastian/resource-operations",
-            "version": "2.0.1",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "4d7a795d35b889bf80a0cc04e08d77cedfa917a9"
+                "reference": "31d35ca87926450c44eae7e2611d45a7a65ea8b3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/4d7a795d35b889bf80a0cc04e08d77cedfa917a9",
-                "reference": "4d7a795d35b889bf80a0cc04e08d77cedfa917a9",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/31d35ca87926450c44eae7e2611d45a7a65ea8b3",
+                "reference": "31d35ca87926450c44eae7e2611d45a7a65ea8b3",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1"
+                "php": ">=7.1"
             },
             "type": "library",
             "extra": {
@@ -3190,7 +3277,65 @@
             ],
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "time": "2018-10-04T04:07:39+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T07:30:19+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "1.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "0150cfbc4495ed2df3872fb31b26781e4e077eb4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/0150cfbc4495ed2df3872fb31b26781e4e077eb4",
+                "reference": "0150cfbc4495ed2df3872fb31b26781e4e077eb4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T07:25:11+00:00"
         },
         {
             "name": "sebastian/version",
@@ -3570,20 +3715,20 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.18.1",
+            "version": "v1.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "1c302646f6efc070cd46856e600e5e0684d6b454"
+                "reference": "f4ba089a5b6366e453971d3aad5fe8e897b37f41"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/1c302646f6efc070cd46856e600e5e0684d6b454",
-                "reference": "1c302646f6efc070cd46856e600e5e0684d6b454",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/f4ba089a5b6366e453971d3aad5fe8e897b37f41",
+                "reference": "f4ba089a5b6366e453971d3aad5fe8e897b37f41",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.1"
             },
             "suggest": {
                 "ext-ctype": "For best performance"
@@ -3591,7 +3736,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.18-dev"
+                    "dev-main": "1.20-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -3642,7 +3787,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-07-14T12:35:20+00:00"
+            "time": "2020-10-23T14:02:19+00:00"
         },
         {
             "name": "symfony/process",
@@ -3928,16 +4073,16 @@
         },
         {
             "name": "twig/twig",
-            "version": "v1.44.0",
+            "version": "v1.44.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "e7c93a4af5eba2b0b3cf51d540e0a131187d7410"
+                "reference": "04b15d4c0bb18ddbf82626320ac07f6a73f199c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/e7c93a4af5eba2b0b3cf51d540e0a131187d7410",
-                "reference": "e7c93a4af5eba2b0b3cf51d540e0a131187d7410",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/04b15d4c0bb18ddbf82626320ac07f6a73f199c9",
+                "reference": "04b15d4c0bb18ddbf82626320ac07f6a73f199c9",
                 "shasum": ""
             },
             "require": {
@@ -3998,7 +4143,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-21T12:32:35+00:00"
+            "time": "2020-10-27T19:22:48+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -4372,21 +4517,25 @@
         },
         {
             "name": "zendframework/zend-i18n",
-            "version": "2.9.2",
+            "version": "2.10.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-i18n.git",
-                "reference": "e17a54b3aee333ab156958f570cde630acee8b07"
+                "reference": "84038e6a1838b611dcc491b1c40321fa4c3a123c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-i18n/zipball/e17a54b3aee333ab156958f570cde630acee8b07",
-                "reference": "e17a54b3aee333ab156958f570cde630acee8b07",
+                "url": "https://api.github.com/repos/zendframework/zend-i18n/zipball/84038e6a1838b611dcc491b1c40321fa4c3a123c",
+                "reference": "84038e6a1838b611dcc491b1c40321fa4c3a123c",
                 "shasum": ""
             },
             "require": {
+                "ext-intl": "*",
                 "php": "^5.6 || ^7.0",
                 "zendframework/zend-stdlib": "^2.7 || ^3.0"
+            },
+            "conflict": {
+                "phpspec/prophecy": "<1.9.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "^5.7.27 || ^6.5.14 || ^7.5.16",
@@ -4400,7 +4549,6 @@
                 "zendframework/zend-view": "^2.6.3"
             },
             "suggest": {
-                "ext-intl": "Required for most features of Zend\\I18n; included in default builds of PHP",
                 "zendframework/zend-cache": "Zend\\Cache component",
                 "zendframework/zend-config": "Zend\\Config component",
                 "zendframework/zend-eventmanager": "You should install this package to use the events in the translator",
@@ -4413,8 +4561,8 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.9.x-dev",
-                    "dev-develop": "2.10.x-dev"
+                    "dev-master": "2.10.x-dev",
+                    "dev-develop": "2.11.x-dev"
                 },
                 "zf": {
                     "component": "Zend\\I18n",
@@ -4437,7 +4585,7 @@
                 "zf"
             ],
             "abandoned": "laminas/laminas-i18n",
-            "time": "2019-09-30T12:04:37+00:00"
+            "time": "2019-12-12T14:08:22+00:00"
         },
         {
             "name": "zendframework/zend-json",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit backupGlobals="false"
+					backupStaticAttributes="false"
+					colors="true"
+					convertErrorsToExceptions="true"
+					convertNoticesToExceptions="true"
+					convertWarningsToExceptions="true"
+					processIsolation="false"
+					stopOnFailure="false"
+					bootstrap="./tests/bootstrap.php"
+					>
+
+	<testsuites>
+    <testsuite name="Basic tests">
+			<directory>./tests/</directory>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/src/Header/Consumer/AbstractConsumer.php
+++ b/src/Header/Consumer/AbstractConsumer.php
@@ -9,13 +9,13 @@ namespace ZBateson\MailMimeParser\Header\Consumer;
 use ZBateson\MailMimeParser\Header\Consumer\ConsumerService;
 use ZBateson\MailMimeParser\Header\Part\HeaderPartFactory;
 use ZBateson\MailMimeParser\Header\Part\MimeLiteralPart;
-use SplFixedArray;
+use ArrayIterator;
 use Iterator;
 use NoRewindIterator;
 
 /**
  * Abstract base class for all header token consumers.
- * 
+ *
  * Defines the base parser that loops over tokens, consuming them and creating
  * header parts.
  *
@@ -28,16 +28,16 @@ abstract class AbstractConsumer
      *      get consumer instances for sub-consumers
      */
     protected $consumerService;
-    
+
     /**
      * @var \ZBateson\MailMimeParser\Header\Part\HeaderPartFactory used to construct
      * HeaderPart objects
      */
     protected $partFactory;
-    
+
     /**
      * Initializes the instance.
-     * 
+     *
      * @param ConsumerService $consumerService
      * @param HeaderPartFactory $partFactory
      */
@@ -46,10 +46,10 @@ abstract class AbstractConsumer
         $this->consumerService = $consumerService;
         $this->partFactory = $partFactory;
     }
-    
+
     /**
      * Returns the singleton instance for the class.
-     * 
+     *
      * @param ConsumerService $consumerService
      * @param HeaderPartFactory $partFactory
      */
@@ -62,10 +62,10 @@ abstract class AbstractConsumer
         }
         return $instances[$class];
     }
-    
+
     /**
      * Invokes parsing of a header's value into header parts.
-     * 
+     *
      * @param string $value the raw header value
      * @return \ZBateson\MailMimeParser\Header\Part\HeaderPart[] the array of parsed
      *         parts
@@ -77,22 +77,22 @@ abstract class AbstractConsumer
         }
         return [];
     }
-    
+
     /**
      * Called during construction to set up the list of sub-consumers that will
      * take control from this consumer should a token match a sub-consumer's
      * start token.
-     * 
+     *
      * @return AbstractConsumer[] the array of consumers
      */
     abstract protected function getSubConsumers();
-    
+
     /**
      * Returns this consumer and all unique sub consumers.
-     * 
+     *
      * Loops into the sub-consumers (and their sub-consumers, etc...) finding
      * all unique consumers, and returns them in an array.
-     * 
+     *
      * @return \ZBateson\MailMimeParser\Header\AbstractConsumer[]
      */
     protected function getAllConsumers()
@@ -109,13 +109,13 @@ abstract class AbstractConsumer
         } while (next($found) !== false);
         return $found;
     }
-    
+
     /**
      * Called by __invoke to parse the raw header value into header parts.
-     * 
+     *
      * Calls splitTokens to split the value into token part strings, then calls
      * parseParts to parse the returned array.
-     * 
+     *
      * @param string $value
      * @return \ZBateson\MailMimeParser\Header\Part\HeaderPart[] the array of parsed
      *         parts
@@ -123,26 +123,26 @@ abstract class AbstractConsumer
     private function parseRawValue($value)
     {
         $tokens = $this->splitRawValue($value);
-        return $this->parseTokensIntoParts(new NoRewindIterator(SplFixedArray::fromArray($tokens)));
+        return $this->parseTokensIntoParts(new NoRewindIterator(new ArrayIterator($tokens)));
     }
-    
+
     /**
      * Returns an array of regular expression separators specific to this
      * consumer.  The returned patterns are used to split the header value into
      * tokens for the consumer to parse into parts.
-     * 
+     *
      * Each array element makes part of a generated regular expression that is
      * used in a call to preg_split().  RegEx patterns can be used, and care
      * should be taken to escape special characters.
-     * 
+     *
      * @return string[] the array of patterns
      */
     abstract protected function getTokenSeparators();
-    
+
     /**
      * Returns a list of regular expression markers for this consumer and all
      * sub-consumers by calling 'getTokenSeparators'..
-     * 
+     *
      * @return string[] an array of regular expression markers
      */
     protected function getAllTokenSeparators()
@@ -154,12 +154,12 @@ abstract class AbstractConsumer
         }
         return array_unique($markers);
     }
-    
+
     /**
      * Returns a regex pattern used to split the input header string.  The
      * default implementation calls getAllTokenSeparators and implodes the
      * returned array with the regex OR '|' character as its glue.
-     * 
+     *
      * @return string the regex pattern
      */
     protected function getTokenSplitPattern()
@@ -168,13 +168,13 @@ abstract class AbstractConsumer
         $mimePartPattern = MimeLiteralPart::MIME_PART_PATTERN;
         return '~(' . $mimePartPattern . '|\\\\.|' . $sChars . ')~';
     }
-    
+
     /**
      * Returns an array of split tokens from the input string.
-     * 
+     *
      * The method calls preg_split using getTokenSplitPattern.  The split
      * array will not contain any empty parts and will contain the markers.
-     * 
+     *
      * @param string $rawValue the raw string
      * @return array the array of tokens
      */
@@ -187,33 +187,33 @@ abstract class AbstractConsumer
             PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY
         );
     }
-    
+
     /**
      * Returns true if the passed string token marks the beginning marker for
      * the current consumer.
-     * 
+     *
      * @param string $token the current token
      * @return bool
      */
     abstract protected function isStartToken($token);
-    
+
     /**
      * Returns true if the passed string token marks the end marker for the
      * current consumer.
-     * 
+     *
      * @param string $token the current token
      * @return bool
      */
     abstract protected function isEndToken($token);
-    
+
     /**
      * Constructs and returns a \ZBateson\MailMimeParser\Header\Part\HeaderPart
      * for the passed string token.  If the token should be ignored, the
      * function must return null.
-     * 
+     *
      * The default created part uses the instance's partFactory->newInstance
      * method.
-     * 
+     *
      * @param string $token the token
      * @param bool $isLiteral set to true if the token represents a literal -
      *        e.g. an escaped token
@@ -229,13 +229,13 @@ abstract class AbstractConsumer
         }
         return $this->partFactory->newInstance($token);
     }
-    
+
     /**
      * Iterates through this consumer's sub-consumers checking if the current
      * token triggers a sub-consumer's start token and passes control onto that
      * sub-consumer's parseTokenIntoParts.  If no sub-consumer is responsible
      * for the current token, calls getPartForToken and returns it in an array.
-     * 
+     *
      * @param Iterator $tokens
      * @return \ZBateson\MailMimeParser\Header\Part\HeaderPart[]|array
      */
@@ -251,14 +251,14 @@ abstract class AbstractConsumer
         }
         return [$this->getPartForToken($token, false)];
     }
-    
+
     /**
      * Returns an array of \ZBateson\MailMimeParser\Header\Part\HeaderPart for
      * the current token on the iterator.
-     * 
+     *
      * If the current token is a start token from a sub-consumer, the sub-
      * consumer's parseTokensIntoParts method is called.
-     * 
+     *
      * @param Iterator $tokens
      * @return \ZBateson\MailMimeParser\Header\Part\HeaderPart[]|array
      */
@@ -270,15 +270,15 @@ abstract class AbstractConsumer
         }
         return $this->getConsumerTokenParts($tokens);
     }
-    
+
     /**
      * Determines if the iterator should be advanced to the next token after
      * reading tokens or finding a start token.
-     * 
+     *
      * The default implementation will advance for a start token, but not
      * advance on the end token of the current consumer, allowing the end token
      * to be passed up to a higher-level consumer.
-     * 
+     *
      * @param Iterator $tokens
      * @param bool $isStartToken
      */
@@ -288,22 +288,22 @@ abstract class AbstractConsumer
             $tokens->next();
         }
     }
-    
+
     /**
      * Iterates over the passed token Iterator and returns an array of parsed
      * \ZBateson\MailMimeParser\Header\Part\HeaderPart objects.
-     * 
+     *
      * The method checks each token to see if the token matches a sub-consumer's
      * start token, or if it matches the current consumer's end token to stop
      * processing.
-     * 
+     *
      * If a sub-consumer's start token is matched, the sub-consumer is invoked
      * and its returned parts are merged to the current consumer's header parts.
-     * 
+     *
      * After all tokens are read and an array of Header\Parts are constructed,
      * the array is passed to AbstractConsumer::processParts for any final
      * processing.
-     * 
+     *
      * @param Iterator $tokens an iterator over a string of tokens
      * @return \ZBateson\MailMimeParser\Header\Part\HeaderPart[] an array of
      *         parsed parts
@@ -317,14 +317,14 @@ abstract class AbstractConsumer
         }
         return $this->processParts($parts);
     }
-    
+
     /**
      * Performs any final processing on the array of parsed parts before
      * returning it to the consumer client.
-     * 
+     *
      * The default implementation simply returns the passed array after
      * filtering out null/empty parts.
-     * 
+     *
      * @param \ZBateson\MailMimeParser\Header\Part\HeaderPart[] $parts
      * @return \ZBateson\MailMimeParser\Header\Part\HeaderPart[]
      */

--- a/tests/MailMimeParser/ContainerTest.php
+++ b/tests/MailMimeParser/ContainerTest.php
@@ -14,12 +14,12 @@ use PHPUnit\Framework\TestCase;
 class ContainerTest extends TestCase
 {
     private $di;
-    
-    protected function setUp()
+
+    protected function setUp(): void
     {
         $this->di = new Container();
     }
-    
+
     public function testNewMessageParser()
     {
         $mp = $this->di->newMessageParser();

--- a/tests/MailMimeParser/Header/AddressHeaderTest.php
+++ b/tests/MailMimeParser/Header/AddressHeaderTest.php
@@ -17,7 +17,7 @@ class AddressHeaderTest extends TestCase
 {
     protected $consumerService;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $charsetConverter = $this->getMockBuilder('ZBateson\MbWrapper\MbWrapper')
 			->setMethods(['__toString'])

--- a/tests/MailMimeParser/Header/Consumer/AbstractConsumerTest.php
+++ b/tests/MailMimeParser/Header/Consumer/AbstractConsumerTest.php
@@ -15,7 +15,7 @@ class AbstractConsumerTest extends TestCase
 {
     private $abstractConsumerStub;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $stub = $this->getMockBuilder('\ZBateson\MailMimeParser\Header\Consumer\AbstractConsumer')
             ->setMethods(['processParts', 'isEndToken', 'getPartForToken', 'getTokenSeparators', 'getSubConsumers'])

--- a/tests/MailMimeParser/Header/Consumer/AddressBaseConsumerTest.php
+++ b/tests/MailMimeParser/Header/Consumer/AddressBaseConsumerTest.php
@@ -16,7 +16,7 @@ class AddressBaseConsumerTest extends TestCase
 {
     private $addressBaseConsumer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $charsetConverter = $this->getMockBuilder('ZBateson\MbWrapper\MbWrapper')
 			->setMethods(['__toString'])

--- a/tests/MailMimeParser/Header/Consumer/AddressConsumerTest.php
+++ b/tests/MailMimeParser/Header/Consumer/AddressConsumerTest.php
@@ -16,7 +16,7 @@ class AddressConsumerTest extends TestCase
 {
     private $addressConsumer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $charsetConverter = $this->getMockBuilder('ZBateson\MbWrapper\MbWrapper')
 			->setMethods(['__toString'])

--- a/tests/MailMimeParser/Header/Consumer/AddressGroupConsumerTest.php
+++ b/tests/MailMimeParser/Header/Consumer/AddressGroupConsumerTest.php
@@ -16,7 +16,7 @@ class AddressGroupConsumerTest extends TestCase
 {
     private $addressGroupConsumer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $charsetConverter = $this->getMockBuilder('ZBateson\MbWrapper\MbWrapper')
 			->setMethods(['__toString'])

--- a/tests/MailMimeParser/Header/Consumer/CommentConsumerTest.php
+++ b/tests/MailMimeParser/Header/Consumer/CommentConsumerTest.php
@@ -16,7 +16,7 @@ class CommentConsumerTest extends TestCase
 {
     private $commentConsumer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $charsetConverter = $this->getMockBuilder('ZBateson\MbWrapper\MbWrapper')
 			->setMethods(['__toString'])

--- a/tests/MailMimeParser/Header/Consumer/ConsumerServiceTest.php
+++ b/tests/MailMimeParser/Header/Consumer/ConsumerServiceTest.php
@@ -16,7 +16,7 @@ class ConsumerServiceTest extends TestCase
 {
     private $consumerService;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $charsetConverter = $this->getMockBuilder('ZBateson\MbWrapper\MbWrapper')
 			->setMethods(['__toString'])

--- a/tests/MailMimeParser/Header/Consumer/DateConsumerTest.php
+++ b/tests/MailMimeParser/Header/Consumer/DateConsumerTest.php
@@ -17,7 +17,7 @@ class DateConsumerTest extends TestCase
 {
     private $dateConsumer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $charsetConverter = $this->getMockBuilder('ZBateson\MbWrapper\MbWrapper')
 			->setMethods(['__toString'])

--- a/tests/MailMimeParser/Header/Consumer/GenericConsumerTest.php
+++ b/tests/MailMimeParser/Header/Consumer/GenericConsumerTest.php
@@ -16,7 +16,7 @@ class GenericConsumerTest extends TestCase
 {
     private $genericConsumer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $charsetConverter = $this->getMockBuilder('ZBateson\MbWrapper\MbWrapper')
 			->setMethods(['__toString'])

--- a/tests/MailMimeParser/Header/Consumer/IdBaseConsumerTest.php
+++ b/tests/MailMimeParser/Header/Consumer/IdBaseConsumerTest.php
@@ -16,7 +16,7 @@ class IdBaseConsumerTest extends TestCase
 {
     private $idBaseConsumer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $charsetConverter = $this->getMockBuilder('ZBateson\MbWrapper\MbWrapper')
 			->setMethods(['__toString'])

--- a/tests/MailMimeParser/Header/Consumer/IdConsumerTest.php
+++ b/tests/MailMimeParser/Header/Consumer/IdConsumerTest.php
@@ -16,7 +16,7 @@ class IdConsumerTest extends TestCase
 {
     private $idConsumer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $charsetConverter = $this->getMockBuilder('ZBateson\MbWrapper\MbWrapper')
 			->setMethods(['__toString'])

--- a/tests/MailMimeParser/Header/Consumer/ParameterConsumerTest.php
+++ b/tests/MailMimeParser/Header/Consumer/ParameterConsumerTest.php
@@ -16,7 +16,7 @@ class ParameterConsumerTest extends TestCase
 {
     private $parameterConsumer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $charsetConverter = $this->getMockBuilder('ZBateson\MbWrapper\MbWrapper')
 			->setMethods(['__toString'])

--- a/tests/MailMimeParser/Header/Consumer/QuotedStringConsumerTest.php
+++ b/tests/MailMimeParser/Header/Consumer/QuotedStringConsumerTest.php
@@ -16,7 +16,7 @@ class QuotedStringConsumerTest extends TestCase
 {
     private $quotedStringConsumer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $charsetConverter = $this->getMockBuilder('ZBateson\MbWrapper\MbWrapper')
 			->setMethods(['__toString'])

--- a/tests/MailMimeParser/Header/Consumer/Received/DomainConsumerTest.php
+++ b/tests/MailMimeParser/Header/Consumer/Received/DomainConsumerTest.php
@@ -15,7 +15,7 @@ class DomainConsumerTest extends TestCase
 {
     private $domainConsumer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $charsetConverter = $this->getMockBuilder('ZBateson\MbWrapper\MbWrapper')
 			->setMethods(['__toString'])

--- a/tests/MailMimeParser/Header/Consumer/Received/GenericReceivedConsumerTest.php
+++ b/tests/MailMimeParser/Header/Consumer/Received/GenericReceivedConsumerTest.php
@@ -15,7 +15,7 @@ class GenericReceivedConsumerTest extends TestCase
 {
     private $genericConsumer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $charsetConverter = $this->getMockBuilder('ZBateson\MbWrapper\MbWrapper')
 			->setMethods(['__toString'])

--- a/tests/MailMimeParser/Header/Consumer/Received/ReceivedDateConsumerTest.php
+++ b/tests/MailMimeParser/Header/Consumer/Received/ReceivedDateConsumerTest.php
@@ -17,7 +17,7 @@ class ReceivedDateConsumerTest extends TestCase
 {
     private $dateConsumer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $charsetConverter = $this->getMockBuilder('ZBateson\MbWrapper\MbWrapper')
 			->setMethods(['__toString'])

--- a/tests/MailMimeParser/Header/Consumer/ReceivedConsumerTest.php
+++ b/tests/MailMimeParser/Header/Consumer/ReceivedConsumerTest.php
@@ -19,7 +19,7 @@ class ReceivedConsumerTest extends TestCase
 {
     private $receivedConsumer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $charsetConverter = $this->getMockBuilder('ZBateson\MbWrapper\MbWrapper')
 			->setMethods(['__toString'])
@@ -161,7 +161,7 @@ class ReceivedConsumerTest extends TestCase
         $this->assertNotEmpty($ret);
 
         $this->assertCount(6, $ret);
-        
+
         $this->assertEquals('from', $ret[0]->getName());
         $this->assertEquals('LeComputer', $ret[0]->getEhloName());
         $this->assertEquals('blah.host', $ret[0]->getHostname());

--- a/tests/MailMimeParser/Header/Consumer/SubjectConsumerTest.php
+++ b/tests/MailMimeParser/Header/Consumer/SubjectConsumerTest.php
@@ -16,7 +16,7 @@ class SubjectConsumerTest extends TestCase
 {
     private $subjectConsumer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $charsetConverter = $this->getMockBuilder('ZBateson\MbWrapper\MbWrapper')
 			->setMethods(['__toString'])

--- a/tests/MailMimeParser/Header/DateHeaderTest.php
+++ b/tests/MailMimeParser/Header/DateHeaderTest.php
@@ -16,7 +16,7 @@ class DateHeaderTest extends TestCase
 {
     protected $consumerService;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $charsetConverter = $this->getMockBuilder('ZBateson\MbWrapper\MbWrapper')
 			->setMethods(['__toString'])

--- a/tests/MailMimeParser/Header/GenericHeaderTest.php
+++ b/tests/MailMimeParser/Header/GenericHeaderTest.php
@@ -16,7 +16,7 @@ class GenericHeaderTest extends TestCase
 {
     protected $consumerService;
 
-    protected function setUp()
+    protected function setUp(): void
     {
 		$charsetConverter = $this->getMockBuilder('ZBateson\MbWrapper\MbWrapper')
 			->setMethods(['__toString'])

--- a/tests/MailMimeParser/Header/HeaderContainerTest.php
+++ b/tests/MailMimeParser/Header/HeaderContainerTest.php
@@ -15,7 +15,7 @@ class HeaderContainerTest extends TestCase
 {
     protected $mockHeaderFactory;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->mockHeaderFactory = $this->getMockBuilder('ZBateson\MailMimeParser\Header\HeaderFactory')
             ->disableOriginalConstructor()

--- a/tests/MailMimeParser/Header/HeaderFactoryTest.php
+++ b/tests/MailMimeParser/Header/HeaderFactoryTest.php
@@ -15,7 +15,7 @@ class HeaderFactoryTest extends TestCase
 {
     protected $headerFactory;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $charsetConverter = $this->getMockBuilder('ZBateson\MbWrapper\MbWrapper')
 			->setMethods(['__toString'])

--- a/tests/MailMimeParser/Header/IdHeaderTest.php
+++ b/tests/MailMimeParser/Header/IdHeaderTest.php
@@ -17,7 +17,7 @@ class IdHeaderTest extends TestCase
     protected $consumerService;
     protected $mimeLiteralPartFactory;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $charsetConverter = $this->getMockBuilder('ZBateson\MbWrapper\MbWrapper')
 			->setMethods(['__toString'])

--- a/tests/MailMimeParser/Header/MimeEncodedHeaderTest.php
+++ b/tests/MailMimeParser/Header/MimeEncodedHeaderTest.php
@@ -25,7 +25,7 @@ class MimeEncodedHeaderTest extends TestCase
     protected $consumerService;
     protected $mimeLiteralPartFactory;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $charsetConverter = $this->getMockBuilder('ZBateson\MbWrapper\MbWrapper')
 			->setMethods(['__toString'])

--- a/tests/MailMimeParser/Header/ParameterHeaderTest.php
+++ b/tests/MailMimeParser/Header/ParameterHeaderTest.php
@@ -16,7 +16,7 @@ class ParameterHeaderTest extends TestCase
 {
     protected $consumerService;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $charsetConverter = $this->getMockBuilder('ZBateson\MbWrapper\MbWrapper')
 			->setMethods(['__toString'])

--- a/tests/MailMimeParser/Header/Part/AddressPartTest.php
+++ b/tests/MailMimeParser/Header/Part/AddressPartTest.php
@@ -17,7 +17,7 @@ class AddressPartTest extends TestCase
 {
     private $charsetConverter;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->charsetConverter = new MbWrapper();
     }

--- a/tests/MailMimeParser/Header/Part/CommentPartTest.php
+++ b/tests/MailMimeParser/Header/Part/CommentPartTest.php
@@ -17,7 +17,7 @@ class CommentPartTest extends TestCase
 {
     private $charsetConverter;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->charsetConverter = new MbWrapper();
     }

--- a/tests/MailMimeParser/Header/Part/DatePartTest.php
+++ b/tests/MailMimeParser/Header/Part/DatePartTest.php
@@ -18,7 +18,7 @@ class DatePartTest extends TestCase
 {
     private $charsetConverter;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->charsetConverter = new MbWrapper();
     }

--- a/tests/MailMimeParser/Header/Part/HeaderPartFactoryTest.php
+++ b/tests/MailMimeParser/Header/Part/HeaderPartFactoryTest.php
@@ -16,7 +16,7 @@ class HeaderPartFactoryTest extends TestCase
 {
     private $headerPartFactory;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $charsetConverter = new MbWrapper();
         $this->headerPartFactory = new HeaderPartFactory($charsetConverter);

--- a/tests/MailMimeParser/Header/Part/HeaderPartTest.php
+++ b/tests/MailMimeParser/Header/Part/HeaderPartTest.php
@@ -16,7 +16,7 @@ class HeaderPartTest extends TestCase
 {
     private $abstractHeaderPartStub;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $charsetConverter = new MbWrapper();
         $stub = $this->getMockBuilder('\ZBateson\MailMimeParser\Header\Part\HeaderPart')

--- a/tests/MailMimeParser/Header/Part/MimeLiteralPartFactoryTest.php
+++ b/tests/MailMimeParser/Header/Part/MimeLiteralPartFactoryTest.php
@@ -16,7 +16,7 @@ class MimeLiteralPartFactoryTest extends TestCase
 {
     protected $headerPartFactory;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $charsetConverter = new MbWrapper();
         $this->headerPartFactory = new MimeLiteralPartFactory($charsetConverter);

--- a/tests/MailMimeParser/Header/Part/MimeLiteralPartTest.php
+++ b/tests/MailMimeParser/Header/Part/MimeLiteralPartTest.php
@@ -17,7 +17,7 @@ class MimeLiteralPartTest extends TestCase
 {
     private $charsetConverter;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->charsetConverter = new MbWrapper();
     }

--- a/tests/MailMimeParser/Header/Part/ParameterPartTest.php
+++ b/tests/MailMimeParser/Header/Part/ParameterPartTest.php
@@ -17,7 +17,7 @@ class ParameterPartTest extends TestCase
 {
     private $charsetConverter;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->charsetConverter = new MbWrapper();
     }

--- a/tests/MailMimeParser/Header/Part/ReceivedDomainPartTest.php
+++ b/tests/MailMimeParser/Header/Part/ReceivedDomainPartTest.php
@@ -17,7 +17,7 @@ class ReceivedDomainPartTest extends TestCase
 {
     private $charsetConverter;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->charsetConverter = new MbWrapper();
     }

--- a/tests/MailMimeParser/Header/Part/ReceivedPartTest.php
+++ b/tests/MailMimeParser/Header/Part/ReceivedPartTest.php
@@ -17,7 +17,7 @@ class ReceivedPartTest extends TestCase
 {
     private $charsetConverter;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->charsetConverter = new MbWrapper();
     }

--- a/tests/MailMimeParser/Header/Part/SplitParameterTokenTest.php
+++ b/tests/MailMimeParser/Header/Part/SplitParameterTokenTest.php
@@ -17,7 +17,7 @@ class SplitParameterTokenTest extends TestCase
 {
     private $charsetConverter;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->charsetConverter = new MbWrapper();
     }

--- a/tests/MailMimeParser/Header/Part/TokenTest.php
+++ b/tests/MailMimeParser/Header/Part/TokenTest.php
@@ -17,7 +17,7 @@ class TokenTest extends TestCase
 {
     private $charsetConverter;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->charsetConverter = new MbWrapper();
     }

--- a/tests/MailMimeParser/Header/ReceivedHeaderTest.php
+++ b/tests/MailMimeParser/Header/ReceivedHeaderTest.php
@@ -17,7 +17,7 @@ class ReceivedHeaderTest extends TestCase
 {
     protected $consumerService;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $charsetConverter = $this->getMockBuilder('ZBateson\MbWrapper\MbWrapper')
 			->setMethods(['__toString'])

--- a/tests/MailMimeParser/Header/SubjectHeaderTest.php
+++ b/tests/MailMimeParser/Header/SubjectHeaderTest.php
@@ -16,7 +16,7 @@ class SubjectHeaderTest extends TestCase
 {
     protected $consumerService;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $charsetConverter = $this->getMockBuilder('ZBateson\MbWrapper\MbWrapper')
 			->setMethods(['__toString'])

--- a/tests/MailMimeParser/IntegrationTests/EmailFunctionalTest.php
+++ b/tests/MailMimeParser/IntegrationTests/EmailFunctionalTest.php
@@ -25,7 +25,7 @@ class EmailFunctionalTest extends TestCase
     // tries to sign rather than verify a signature
     const USE_GPG_KEYGEN = false;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->parser = new MailMimeParser();
         $this->messageDir = dirname(dirname(__DIR__)) . '/' . TEST_DATA_DIR . '/emails';
@@ -2443,7 +2443,7 @@ class EmailFunctionalTest extends TestCase
         $message->save($tmpSaved);
         rewind($tmpSaved);
 
-        $this->assertContains($signableContent, preg_replace('/\r\n|\r|\n/', "\r\n", stream_get_contents($tmpSaved)));
+        $this->assertStringContainsStringIgnoringCase($signableContent, preg_replace('/\r\n|\r|\n/', "\r\n", stream_get_contents($tmpSaved)));
         rewind($tmpSaved);
 
         $messageWritten = $this->parser->parse($tmpSaved);
@@ -2495,7 +2495,7 @@ class EmailFunctionalTest extends TestCase
         $message->save($tmpSaved);
         rewind($tmpSaved);
 
-        $this->assertContains($signableContent, preg_replace('/\r\n|\r|\n/', "\r\n", stream_get_contents($tmpSaved)));
+        $this->assertStringContainsStringIgnoringCase($signableContent, preg_replace('/\r\n|\r|\n/', "\r\n", stream_get_contents($tmpSaved)));
         rewind($tmpSaved);
 
         $messageWritten = $this->parser->parse($tmpSaved);
@@ -2546,7 +2546,7 @@ class EmailFunctionalTest extends TestCase
         $message->save($tmpSaved);
         rewind($tmpSaved);
 
-        $this->assertContains($signableContent, preg_replace('/\r\n|\r|\n/', "\r\n", stream_get_contents($tmpSaved)));
+        $this->assertStringContainsStringIgnoringCase($signableContent, preg_replace('/\r\n|\r|\n/', "\r\n", stream_get_contents($tmpSaved)));
         rewind($tmpSaved);
 
         $messageWritten = $this->parser->parse($tmpSaved);
@@ -2595,7 +2595,7 @@ class EmailFunctionalTest extends TestCase
         $message->save($tmpSaved);
         rewind($tmpSaved);
 
-        $this->assertContains($signableContent, preg_replace('/\r\n|\r|\n/', "\r\n", stream_get_contents($tmpSaved)));
+        $this->assertStringContainsStringIgnoringCase($signableContent, preg_replace('/\r\n|\r|\n/', "\r\n", stream_get_contents($tmpSaved)));
         rewind($tmpSaved);
 
         $messageWritten = $this->parser->parse($tmpSaved);
@@ -2644,7 +2644,7 @@ class EmailFunctionalTest extends TestCase
         $message->save($tmpSaved);
         rewind($tmpSaved);
 
-        $this->assertContains($signableContent, preg_replace('/\r\n|\r|\n/', "\r\n", stream_get_contents($tmpSaved)));
+        $this->assertStringContainsStringIgnoringCase($signableContent, preg_replace('/\r\n|\r|\n/', "\r\n", stream_get_contents($tmpSaved)));
         rewind($tmpSaved);
 
         $messageWritten = $this->parser->parse($tmpSaved);
@@ -2693,7 +2693,7 @@ class EmailFunctionalTest extends TestCase
         $message->save($tmpSaved);
         rewind($tmpSaved);
 
-        $this->assertContains($signableContent, preg_replace('/\r\n|\r|\n/', "\r\n", stream_get_contents($tmpSaved)));
+        $this->assertStringContainsStringIgnoringCase($signableContent, preg_replace('/\r\n|\r|\n/', "\r\n", stream_get_contents($tmpSaved)));
         rewind($tmpSaved);
 
         $messageWritten = $this->parser->parse($tmpSaved);
@@ -2741,7 +2741,7 @@ class EmailFunctionalTest extends TestCase
         $message->save($tmpSaved);
         rewind($tmpSaved);
 
-        $this->assertContains($signableContent, preg_replace('/\r\n|\r|\n/', "\r\n", stream_get_contents($tmpSaved)));
+        $this->assertStringContainsStringIgnoringCase($signableContent, preg_replace('/\r\n|\r|\n/', "\r\n", stream_get_contents($tmpSaved)));
         rewind($tmpSaved);
 
         $messageWritten = $this->parser->parse($tmpSaved);

--- a/tests/MailMimeParser/MailMimeParserTest.php
+++ b/tests/MailMimeParser/MailMimeParserTest.php
@@ -15,8 +15,8 @@ class MailMimeParserTest extends TestCase
 {
     private $mockDi;
     private $mmp;
-    
-    protected function setUp()
+
+    protected function setUp(): void
     {
         $this->mockDi = $this->getMockBuilder('ZBateson\MailMimeParser\Container')
             ->disableOriginalConstructor()
@@ -24,7 +24,7 @@ class MailMimeParserTest extends TestCase
             ->getMock();
         $this->mmp = new MailMimeParser($this->mockDi);
     }
-    
+
     public function testConstructMailMimeParser()
     {
         $this->assertNotNull($this->mmp);

--- a/tests/MailMimeParser/Message/Helper/GenericHelperTest.php
+++ b/tests/MailMimeParser/Message/Helper/GenericHelperTest.php
@@ -20,7 +20,7 @@ class GenericHelperTest extends TestCase
     private $mockUUEncodedPartFactory;
     private $mockPartBuilderFactory;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->mockMimePartFactory = $this->getMockBuilder('ZBateson\MailMimeParser\Message\Part\Factory\MimePartFactory')
             ->disableOriginalConstructor()

--- a/tests/MailMimeParser/Message/Helper/MultipartHelperTest.php
+++ b/tests/MailMimeParser/Message/Helper/MultipartHelperTest.php
@@ -19,7 +19,7 @@ class MultipartHelperTest extends TestCase
     private $mockPartBuilderFactory;
     private $mockGenericHelper;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->mockMimePartFactory = $this->getMockBuilder('ZBateson\MailMimeParser\Message\Part\Factory\MimePartFactory')
             ->disableOriginalConstructor()

--- a/tests/MailMimeParser/Message/Helper/PrivacyHelperTest.php
+++ b/tests/MailMimeParser/Message/Helper/PrivacyHelperTest.php
@@ -21,7 +21,7 @@ class PrivacyHelperTest extends TestCase
     private $mockGenericHelper;
     private $mockMultipartHelper;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->mockMimePartFactory = $this->getMockBuilder('ZBateson\MailMimeParser\Message\Part\Factory\MimePartFactory')
             ->disableOriginalConstructor()

--- a/tests/MailMimeParser/Message/MessageFactoryTest.php
+++ b/tests/MailMimeParser/Message/MessageFactoryTest.php
@@ -16,7 +16,7 @@ class MessageFactoryTest extends TestCase
 {
     protected $messageFactory;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $mocksdf = $this->getMockBuilder('ZBateson\MailMimeParser\Stream\StreamFactory')
             ->getMock();

--- a/tests/MailMimeParser/Message/MessageParserTest.php
+++ b/tests/MailMimeParser/Message/MessageParserTest.php
@@ -23,7 +23,7 @@ class MessageParserTest extends TestCase
     protected $mimePartFactory;
     protected $vfs;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->vfs = vfsStream::setup('root');
 

--- a/tests/MailMimeParser/Message/Part/Factory/MimePartFactoryTest.php
+++ b/tests/MailMimeParser/Message/Part/Factory/MimePartFactoryTest.php
@@ -18,7 +18,7 @@ class MimePartFactoryTest extends TestCase
     protected $mimePartFactory;
     protected $partFilterFactory;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $mocksdf = $this->getMockBuilder('ZBateson\MailMimeParser\Stream\StreamFactory')
             ->getMock();

--- a/tests/MailMimeParser/Message/Part/Factory/NonMimePartFactoryTest.php
+++ b/tests/MailMimeParser/Message/Part/Factory/NonMimePartFactoryTest.php
@@ -17,7 +17,7 @@ class NonMimePartFactoryTest extends TestCase
 {
     protected $nonMimePartFactory;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $mocksdf = $this->getMockBuilder('ZBateson\MailMimeParser\Stream\StreamFactory')
             ->getMock();

--- a/tests/MailMimeParser/Message/Part/Factory/PartBuilderFactoryTest.php
+++ b/tests/MailMimeParser/Message/Part/Factory/PartBuilderFactoryTest.php
@@ -15,7 +15,7 @@ class PartBuilderFactoryTest extends TestCase
 {
     protected $partBuilderFactory;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $mockHeaderFactory = $this->getMockBuilder('ZBateson\MailMimeParser\Header\HeaderFactory')
             ->disableOriginalConstructor()

--- a/tests/MailMimeParser/Message/Part/Factory/PartStreamFilterManagerFactoryTest.php
+++ b/tests/MailMimeParser/Message/Part/Factory/PartStreamFilterManagerFactoryTest.php
@@ -15,7 +15,7 @@ class PartStreamFilterManagerFactoryTest extends TestCase
 {
     protected $partStreamFilterManagerFactory;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $mocksdf = $this->getMockBuilder('ZBateson\MailMimeParser\Stream\StreamFactory')
             ->getMock();

--- a/tests/MailMimeParser/Message/Part/Factory/UUEncodedPartFactoryTest.php
+++ b/tests/MailMimeParser/Message/Part/Factory/UUEncodedPartFactoryTest.php
@@ -17,7 +17,7 @@ class UUEncodedPartFactoryTest extends TestCase
 {
     protected $uuEncodedPartFactory;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $mocksdf = $this->getMockBuilder('ZBateson\MailMimeParser\Stream\StreamFactory')
             ->getMock();

--- a/tests/MailMimeParser/Message/Part/MessagePartTest.php
+++ b/tests/MailMimeParser/Message/Part/MessagePartTest.php
@@ -22,7 +22,7 @@ class MessagePartTest extends TestCase {
     protected $streamFactory;
     private $vfs;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->vfs = vfsStream::setup('root');
         $psf = $this->getMockBuilder('ZBateson\MailMimeParser\Message\Part\PartStreamFilterManager')

--- a/tests/MailMimeParser/Message/Part/MimePartTest.php
+++ b/tests/MailMimeParser/Message/Part/MimePartTest.php
@@ -22,7 +22,7 @@ class MimePartTest extends TestCase
     private $mockPartFilterFactory;
     private $mockStreamFactory;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->mockPartStreamFilterManager = $this->getMockBuilder('ZBateson\MailMimeParser\Message\Part\PartStreamFilterManager')
             ->disableOriginalConstructor()

--- a/tests/MailMimeParser/Message/Part/PartBuilderTest.php
+++ b/tests/MailMimeParser/Message/Part/PartBuilderTest.php
@@ -16,7 +16,7 @@ class PartBuilderTest extends TestCase
 {
     private $mockMessagePartFactory;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->mockMessagePartFactory = $this->getMockBuilder('ZBateson\MailMimeParser\Message\Part\Factory\MessagePartFactory')
             ->disableOriginalConstructor()

--- a/tests/MailMimeParser/Message/Part/PartStreamFilterManagerTest.php
+++ b/tests/MailMimeParser/Message/Part/PartStreamFilterManagerTest.php
@@ -18,7 +18,7 @@ class PartStreamFilterManagerTest extends TestCase
     private $partStreamFilterManager = null;
     private $mockStreamFactory = null;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $mocksdf = $this->getMockBuilder('ZBateson\MailMimeParser\Stream\StreamFactory')
             ->getMock();

--- a/tests/MailMimeParser/Message/PartFilterFactoryTest.php
+++ b/tests/MailMimeParser/Message/PartFilterFactoryTest.php
@@ -16,7 +16,7 @@ class PartFilterFactoryTest extends TestCase
 {
     protected $partFilterFactory;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->partFilterFactory = new PartFilterFactory();
     }

--- a/tests/MailMimeParser/Message/PartFilterTest.php
+++ b/tests/MailMimeParser/Message/PartFilterTest.php
@@ -47,7 +47,7 @@ class PartFilterTest extends TestCase
         return $part;
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $signedPart = $this->getMockedSignedPart();

--- a/tests/MailMimeParser/MessageTest.php
+++ b/tests/MailMimeParser/MessageTest.php
@@ -22,7 +22,7 @@ class MessageTest extends TestCase
     private $mockMessageHelperService;
     private $vfs;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->vfs = vfsStream::setup('root');
         $this->mockPartStreamFilterManager = $this->getMockBuilder('ZBateson\MailMimeParser\Message\Part\PartStreamFilterManager')

--- a/tests/MailMimeParser/Stream/MessagePartStreamTest.php
+++ b/tests/MailMimeParser/Stream/MessagePartStreamTest.php
@@ -17,7 +17,7 @@ class MessagePartStreamTest extends TestCase
 {
     private $mockStreamFactory;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->mockStreamFactory = $this->getMockBuilder('ZBateson\MailMimeParser\Stream\StreamFactory')
             ->disableOriginalConstructor()

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,2 +1,6 @@
 <?php
+
+define ('TEST_DATA_DIR', '_data');
+define ('TEST_OUTPUT_DIR', '_output');
+
 $loader = require_once dirname(__DIR__) . '/vendor/autoload.php';


### PR DESCRIPTION
Updated to use PHPUnit 8.  This is for reference, not intended for immediate release.

 * Incompatible with PHP 7,0 and lower
 * Added PHP 8.0 support for Travis CI and removed 7.0 and below