### PR TITLE
Add missing nullable return type annotation

### DIFF
--- a/src/Message/Part/ParentHeaderPart.php
+++ b/src/Message/Part/ParentHeaderPart.php
@@ -70,6 +70,7 @@ abstract class ParentHeaderPart extends ParentPart
      *         |\ZBateson\MailMimeParser\Header\ParameterHeader
      *         |\ZBateson\MailMimeParser\Header\ReceivedHeader
      *         |\ZBateson\MailMimeParser\Header\SubjectHeader
+     *         |null
      */
     public function getHeader($name, $offset = 0)
     {


### PR DESCRIPTION
Add missing nullable return type annotation to ParentHeaderPart::getHeader()