### PR TITLE
Add support for PHP 8.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.0, 7.4, 7.3, 7.2, 7.1, 7.0, 5.6, 5.5, 5.4]
+        php: [8.1, 8.0, 7.4, 7.3, 7.2, 7.1, 7.0, 5.6, 5.5, 5.4]
         stability: [prefer-stable]
 
     name: P${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,45 +1,47 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
-    bootstrap="./bootstrap.php"
-    colors="true"
-    convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
-    stopOnError="false"
-    stopOnFailure="false"
-    stopOnIncomplete="false"
-    stopOnSkipped="false">
-    <php>
-        <const name="TEST_DATA_DIR" value="_data"/>
-        <const name="TEST_OUTPUT_DIR" value="_output"/>
-    </php>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">../src/</directory>
-        </whitelist>
-    </filter>
-    <!--
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        bootstrap="./bootstrap.php"
+        colors="true"
+        convertNoticesToExceptions="true"
+        convertWarningsToExceptions="true"
+        stopOnError="false"
+        stopOnFailure="false"
+        stopOnIncomplete="false"
+        stopOnSkipped="false"
+        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">../src/</directory>
+    </include>
+  </coverage>
+  <php>
+    <const name="TEST_DATA_DIR" value="_data"/>
+    <const name="TEST_OUTPUT_DIR" value="_output"/>
+  </php>
+  <!--
     Files specified in order for code coverage reporting - for example, Container
     as a singleton instance only gets constructed once, and for coverage to be
     reported correctly, needs to be the first class tested.
     -->
-    <testsuites>
-        <testsuite name="Base">
-            <directory suffix="Test.php">MailMimeParser</directory>
-        </testsuite>
-        <testsuite name="Header">
-            <directory suffix="Test.php">MailMimeParser/Header</directory>
-        </testsuite>
-        <testsuite name="Message">
-            <directory suffix="Test.php">MailMimeParser/Message</directory>
-        </testsuite>
-        <testsuite name="Parser">
-            <directory suffix="Test.php">MailMimeParser/Parser</directory>
-        </testsuite>
-        <testsuite name="Stream">
-            <directory suffix="Test.php">MailMimeParser/Stream</directory>
-        </testsuite>
-        <testsuite name="Integration">
-            <directory suffix="Test.php">MailMimeParser/IntegrationTests</directory>
-        </testsuite>
-    </testsuites>
+  <testsuites>
+    <testsuite name="Base">
+      <directory suffix="Test.php">MailMimeParser</directory>
+    </testsuite>
+    <testsuite name="Header">
+      <directory suffix="Test.php">MailMimeParser/Header</directory>
+    </testsuite>
+    <testsuite name="Message">
+      <directory suffix="Test.php">MailMimeParser/Message</directory>
+    </testsuite>
+    <testsuite name="Parser">
+      <directory suffix="Test.php">MailMimeParser/Parser</directory>
+    </testsuite>
+    <testsuite name="Stream">
+      <directory suffix="Test.php">MailMimeParser/Stream</directory>
+    </testsuite>
+    <testsuite name="Integration">
+      <directory suffix="Test.php">MailMimeParser/IntegrationTests</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>


### PR DESCRIPTION
Opened in draft as a test is failing. I haven't figured out what changed in 8.1 for this to happen. I know html encoding and decoding functions handle single quotes differently in 8.1, but I don't think they are used anywhere?

Fyi, it's the first `'` in `'﻿这也不会,那也不会'` that is different.

While searching for a solution on this, I quickly tried to migrate zbateson/mb-wrapper to Github Actions, but for some reason that's not working as suspected. Feel free to fix or just close that PR: https://github.com/zbateson/mb-wrapper/pull/5