### PR TITLE
Adding #[\ReturnTypeWillChange] for PHP8.1 compatibility

### DIFF
--- a/src/Message/MessagePart.php
+++ b/src/Message/MessagePart.php
@@ -57,16 +57,19 @@ abstract class MessagePart implements IMessagePart
         $this->observers = new SplObjectStorage();
     }
 
+    #[\ReturnTypeWillChange]
     public function attach(SplObserver $observer)
     {
         $this->observers->attach($observer);
     }
 
+    #[\ReturnTypeWillChange]
     public function detach(SplObserver $observer)
     {
         $this->observers->detach($observer);
     }
 
+    #[\ReturnTypeWillChange]
     public function notify()
     {
         foreach ($this->observers as $observer) {

--- a/src/Message/PartChildrenContainer.php
+++ b/src/Message/PartChildrenContainer.php
@@ -37,9 +37,10 @@ class PartChildrenContainer implements RecursiveIterator, ArrayAccess
      * Returns true if the current element is an IMultiPart and doesn't return
      * null for {@see IMultiPart::getChildIterator()}.  Note that the iterator
      * may still be empty.
-     * 
+     *
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function hasChildren()
     {
         return ($this->current() instanceof IMultiPart
@@ -52,6 +53,7 @@ class PartChildrenContainer implements RecursiveIterator, ArrayAccess
      *
      * @return RecursiveIterator|null the iterator
      */
+    #[\ReturnTypeWillChange]
     public function getChildren()
     {
         if ($this->current() instanceof IMultiPart) {
@@ -60,26 +62,31 @@ class PartChildrenContainer implements RecursiveIterator, ArrayAccess
         return null;
     }
 
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return $this->offsetGet($this->position);
     }
 
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return $this->position;
     }
 
+    #[\ReturnTypeWillChange]
     public function next()
     {
         ++$this->position;
     }
 
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         $this->position = 0;
     }
 
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return $this->offsetExists($this->position);
@@ -112,6 +119,7 @@ class PartChildrenContainer implements RecursiveIterator, ArrayAccess
      * @param IMessagePart $part The part to remove.
      * @return int the 0-based position it previously occupied.
      */
+    #[\ReturnTypeWillChange]
     public function remove(IMessagePart $part)
     {
         foreach ($this->children as $key => $child) {
@@ -123,16 +131,19 @@ class PartChildrenContainer implements RecursiveIterator, ArrayAccess
         return null;
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->children[$offset]);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->offsetExists($offset) ? $this->children[$offset] : null;
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (!$value instanceof IMessagePart) {
@@ -147,6 +158,7 @@ class PartChildrenContainer implements RecursiveIterator, ArrayAccess
         }
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         array_splice($this->children, $offset, 1);

--- a/src/Message/PartHeaderContainer.php
+++ b/src/Message/PartHeaderContainer.php
@@ -111,7 +111,7 @@ class PartHeaderContainer implements IteratorAggregate
     /**
      * Returns the IHeader object for the header with the given $name, or null
      * if none exist.
-     * 
+     *
      * An optional offset can be provided, which defaults to the first header in
      * the collection when more than one header with the same name exists.
      *
@@ -290,6 +290,7 @@ class PartHeaderContainer implements IteratorAggregate
      *
      * @return ArrayIterator
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayIterator($this->getHeaders());

--- a/src/Parser/Part/ParserPartStreamContainer.php
+++ b/src/Parser/Part/ParserPartStreamContainer.php
@@ -21,7 +21,7 @@ use SplSubject;
  * stream as the part's stream instead of the PartStreamContainer's
  * MessagePartStream (which dynamically creates a stream from an IMessagePart)
  * unless the part changed.
- * 
+ *
  * The ParserPartStreamContainer must also be attached to its underlying part
  * with SplSubject::attach() so the ParserPartStreamContainer gets notified of
  * any changes.
@@ -143,6 +143,7 @@ class ParserPartStreamContainer extends PartStreamContainer implements SplObserv
         return parent::getStream();
     }
 
+    #[\ReturnTypeWillChange]
     public function update(SplSubject $subject)
     {
         $this->partUpdated = true;

--- a/src/Stream/MessagePartStream.php
+++ b/src/Stream/MessagePartStream.php
@@ -41,7 +41,7 @@ class MessagePartStream implements StreamInterface, SplObserver
 
     /**
      * Constructor
-     * 
+     *
      * @param StreamFactory $sdf
      * @param IMessagePart $part
      */
@@ -59,6 +59,7 @@ class MessagePartStream implements StreamInterface, SplObserver
         }
     }
 
+    #[\ReturnTypeWillChange]
     public function update(SplSubject $subject)
     {
         if ($this->appendStream !== null) {
@@ -89,7 +90,7 @@ class MessagePartStream implements StreamInterface, SplObserver
         }
         return $stream;
     }
-    
+
     /**
      * Attaches and returns a transfer encoding stream decorator to the passed
      * $stream.
@@ -173,7 +174,7 @@ class MessagePartStream implements StreamInterface, SplObserver
             $streams[] = $child->getStream();
         }
         $streams[] = Psr7\Utils::streamFor("\r\n--$boundary--\r\n");
-        
+
         return $streams;
     }
 


### PR DESCRIPTION
PHP 8.1 expects return types to be correctly specified and match the parent class.  Missing and mismatched return types are now a depreciated feature. This PR makes sure PHP 8.1 does not emit warnings on missing or mismatched return type.

#[\ReturnTypeWillChange] is an official attribute in 8.1 and comment in previous versions, so this should not be an issue for all versions.

Unfortunately PHP 8.2 or 8.3 will probably matching return types, so that means supporting anything less than 7.1 will not be possible. At this point, 7.0 and lower have about 2% share according to Packagist.org, so dropping support for 7.0 and lower would probably not have a big impact on users.  They can still use the older versions.