### PR TITLE
Fix: empty utf8 quoted not parsed correctly

### DIFF
--- a/src/Header/Part/MimeLiteralPart.php
+++ b/src/Header/Part/MimeLiteralPart.php
@@ -125,7 +125,7 @@ class MimeLiteralPart extends LiteralPart
      */
     private function decodeSplitPart($entity)
     {
-        if (preg_match('/^=\?([A-Za-z\-_0-9]+)\*?([A-Za-z\-_0-9]+)?\?([QBqb])\?([^\?]+)\?=$/', $entity, $matches)) {
+        if (preg_match('/^=\?([A-Za-z\-_0-9]+)\*?([A-Za-z\-_0-9]+)?\?([QBqb])\?([^\?]*)\?=$/', $entity, $matches)) {
             return $this->decodeMatchedEntity($matches);
         }
         $decoded = $this->convertEncoding($entity);

--- a/tests/MailMimeParser/Header/Part/MimeLiteralPartTest.php
+++ b/tests/MailMimeParser/Header/Part/MimeLiteralPartTest.php
@@ -47,6 +47,13 @@ class MimeLiteralPartTest extends TestCase
         $this->assertDecoded('Kilgore Trout', '=?US-ASCII?Q?Kilgore_Trout?=');
     }
 
+    public function testDecodeEmpty()
+    {
+        $this->assertDecoded('', '=?US-ASCII?Q??=');
+        $this->assertDecoded('', '=?utf-8?Q??=');
+    }
+
+
     public function testMimeEncodingNullLanguage()
     {
         $part = $this->assertDecoded('Kilgore Trout', '=?US-ASCII?Q?Kilgore_Trout?=');


### PR DESCRIPTION
Fix issue https://github.com/zbateson/mail-mime-parser/issues/160