### PR TITLE
Fix parameter name of IMessage::setHtmlPart according to docComment

### DIFF
--- a/src/IMessage.php
+++ b/src/IMessage.php
@@ -184,7 +184,7 @@ interface IMessage extends IMimePart
      * @param string $contentTypeCharset the charset to use as the text/html
      *        part's content-type header charset value.
      */
-    public function setHtmlPart($resource, $charset = 'UTF-8');
+    public function setHtmlPart($resource, $contentTypeCharset = 'UTF-8');
 
     /**
      * Removes the text/plain part of the message at the passed index if one


### PR DESCRIPTION
Currently the comment and signature of `IMessage::setHtmlPart` is

```php
    /**
     * [...]
     * @param string $contentTypeCharset the charset to use as the text/html
     *        part's content-type header charset value.
     */
    public function setHtmlPart($resource, $charset = 'UTF-8');
```

Symfony's DeprecationErrorHandler thinks that in the next main version of the package there will be a new parameter for this function:

> Remaining indirect deprecation notices (1)
> 
>  1x: The "ZBateson\MailMimeParser\Message::setHtmlPart()" method will require a new "string $contentTypeCharset" argument in the next major version of its interface "ZBateson\MailMimeParser\IMessage", not defining it is deprecated.

So I propose to change the parameter's name in the interface according to the name in the php doc.