### PR TITLE
Fix PHP 8.1 return type deprecation notices

### DIFF
--- a/src/Stream/HeaderStream.php
+++ b/src/Stream/HeaderStream.php
@@ -48,6 +48,10 @@ class HeaderStream implements StreamInterface, SplObserver
         }
     }
 
+    /**
+     * @return void
+     */
+    #[\ReturnTypeWillChange]
     public function update(SplSubject $subject)
     {
         if ($this->stream !== null) {


### PR DESCRIPTION
Still missing in HeaderStream.

Got following message in our unit testing code:
```
PHP Deprecated:  Return type of ZBateson\MailMimeParser\Stream\HeaderStream::update(SplSubject $subject) should either be compatible with SplObserver::update(SplSubject $subject): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /home/runner/work/mobilityshop-api/mobilityshop-api/vendor/zbateson/mail-mime-parser/src/Stream/HeaderStream.php on line 51
```