### PR TITLE
Fixed null to string warnings in MimePart->getContentType()

### DIFF
--- a/src/Message/MimePart.php
+++ b/src/Message/MimePart.php
@@ -257,7 +257,7 @@ class MimePart extends MultiPart implements IMimePart
     {
         $header = $this->getHeader($name);
         if ($header !== null) {
-            return $header->getValue();
+            return $header->getValue() ?? $defaultValue;
         }
         return $defaultValue;
     }

--- a/src/Message/MimePart.php
+++ b/src/Message/MimePart.php
@@ -257,7 +257,7 @@ class MimePart extends MultiPart implements IMimePart
     {
         $header = $this->getHeader($name);
         if ($header !== null) {
-            return $header->getValue() ?? $defaultValue;
+            return $header->getValue() ?: $defaultValue;
         }
         return $defaultValue;
     }


### PR DESCRIPTION
`MimePart::getContentType()` applies `strtolower()` on the result of `getHeaderValue()`. However, this result can be `null` even though the default value is provided as the default value is not used if the header is present but empty:
```
Content-Type:
```
In such cases, the result is `null` and PHP 8.1 complains:
```
strtolower(): Passing null to parameter #1 ($string) of type string is deprecated
```
My fix applies the default value even if the header is present but empty as in the example above.