### PR TITLE
Return $this instead of void

### DIFF
--- a/src/Header/AbstractHeader.php
+++ b/src/Header/AbstractHeader.php
@@ -67,10 +67,12 @@ abstract class AbstractHeader implements IHeader
      *
      * The default implementation assigns the returned value to $this->part.
      *
+     * @return static
      */
-    protected function setParseHeaderValue(AbstractConsumer $consumer) : void
+    protected function setParseHeaderValue(AbstractConsumer $consumer)
     {
         $this->parts = $consumer($this->rawValue);
+        return $this;
     }
 
     /**

--- a/src/Header/AddressHeader.php
+++ b/src/Header/AddressHeader.php
@@ -50,8 +50,9 @@ class AddressHeader extends AbstractHeader
     /**
      * Overridden to extract all addresses into addresses array.
      *
+     * @return static
      */
-    protected function setParseHeaderValue(AbstractConsumer $consumer) : void
+    protected function setParseHeaderValue(AbstractConsumer $consumer)
     {
         parent::setParseHeaderValue($consumer);
         foreach ($this->parts as $part) {
@@ -62,6 +63,7 @@ class AddressHeader extends AbstractHeader
                 $this->groups[] = $part;
             }
         }
+        return $this;
     }
 
     /**

--- a/src/Header/Consumer/AbstractConsumer.php
+++ b/src/Header/Consumer/AbstractConsumer.php
@@ -276,12 +276,15 @@ abstract class AbstractConsumer
      *
      * @param Iterator $tokens The token iterator.
      * @param bool $isStartToken true for the start token.
+     *
+     * @return static
      */
-    protected function advanceToNextToken(Iterator $tokens, bool $isStartToken) : void
+    protected function advanceToNextToken(Iterator $tokens, bool $isStartToken)
     {
         if (($isStartToken) || ($tokens->valid() && !$this->isEndToken($tokens->current()))) {
             $tokens->next();
         }
+        return $this;
     }
 
     /**

--- a/src/Header/Consumer/AddressBaseConsumer.php
+++ b/src/Header/Consumer/AddressBaseConsumer.php
@@ -49,13 +49,16 @@ class AddressBaseConsumer extends AbstractConsumer
      *
      * The start token for AddressBaseConsumer is part of an AddressPart (or a
      * sub-consumer) and so must be passed on.
+     *
+     * @return static
      */
-    protected function advanceToNextToken(Iterator $tokens, bool $isStartToken) : void
+    protected function advanceToNextToken(Iterator $tokens, bool $isStartToken)
     {
         if ($isStartToken) {
-            return;
+            return $this;
         }
         parent::advanceToNextToken($tokens, $isStartToken);
+        return $this;
     }
 
     /**

--- a/src/Header/Consumer/CommentConsumer.php
+++ b/src/Header/Consumer/CommentConsumer.php
@@ -80,10 +80,12 @@ class CommentConsumer extends GenericConsumer
      * and will not advance past it.  Because a comment part of a header can be
      * nested, its implementation must advance past its own 'end' token.
      *
+     * @return static
      */
-    protected function advanceToNextToken(Iterator $tokens, bool $isStartToken) : void
+    protected function advanceToNextToken(Iterator $tokens, bool $isStartToken)
     {
         $tokens->next();
+        return $this;
     }
 
     /**

--- a/src/Header/Consumer/GenericConsumer.php
+++ b/src/Header/Consumer/GenericConsumer.php
@@ -85,13 +85,14 @@ class GenericConsumer extends AbstractConsumer
      * @param HeaderPart[] $parts
      * @param HeaderPart[] $retParts
      */
-    private function addSpaceToRetParts(array $parts, array &$retParts, int $curIndex, HeaderPart &$spacePart, HeaderPart $lastPart) : void
+    private function addSpaceToRetParts(array $parts, array &$retParts, int $curIndex, HeaderPart &$spacePart, HeaderPart $lastPart) : self
     {
         $nextPart = $parts[$curIndex];
         if ($this->shouldAddSpace($nextPart, $lastPart)) {
             $retParts[] = $spacePart;
             $spacePart = null;
         }
+        return $this;
     }
 
     /**
@@ -105,12 +106,13 @@ class GenericConsumer extends AbstractConsumer
      * @param HeaderPart[] $retParts
      * @param HeaderPart $spacePart
      */
-    private function addSpaces(array $parts, array &$retParts, int $curIndex, ?HeaderPart &$spacePart = null) : void
+    private function addSpaces(array $parts, array &$retParts, int $curIndex, ?HeaderPart &$spacePart = null) : self
     {
         $lastPart = \end($retParts);
         if ($spacePart !== null && $curIndex < \count($parts) && $parts[$curIndex]->getValue() !== '' && $lastPart !== false) {
             $this->addSpaceToRetParts($parts, $retParts, $curIndex, $spacePart, $lastPart);
         }
+        return $this;
     }
 
     /**

--- a/src/Header/Consumer/ReceivedConsumer.php
+++ b/src/Header/Consumer/ReceivedConsumer.php
@@ -103,7 +103,7 @@ class ReceivedConsumer extends AbstractConsumer
         } elseif ($tokens->valid() && !$this->isEndToken($tokens->current())) {
             foreach ($this->getSubConsumers() as $consumer) {
                 if ($consumer->isStartToken($tokens->current())) {
-                  return $this;
+                    return $this;
                 }
             }
             $tokens->next();

--- a/src/Header/Consumer/ReceivedConsumer.php
+++ b/src/Header/Consumer/ReceivedConsumer.php
@@ -94,19 +94,21 @@ class ReceivedConsumer extends AbstractConsumer
      * Overridden to /not/ advance when the end token matches a start token for
      * a sub-consumer.
      *
+     * @return static
      */
-    protected function advanceToNextToken(Iterator $tokens, bool $isStartToken) : void
+    protected function advanceToNextToken(Iterator $tokens, bool $isStartToken)
     {
         if ($isStartToken) {
             $tokens->next();
         } elseif ($tokens->valid() && !$this->isEndToken($tokens->current())) {
             foreach ($this->getSubConsumers() as $consumer) {
                 if ($consumer->isStartToken($tokens->current())) {
-                    return;
+                  return $this;
                 }
             }
             $tokens->next();
         }
+        return $this;
     }
 
     /**

--- a/src/Header/MimeEncodedHeader.php
+++ b/src/Header/MimeEncodedHeader.php
@@ -38,8 +38,10 @@ abstract class MimeEncodedHeader extends AbstractHeader
     /**
      * Mime-decodes any mime-encoded parts prior to invoking the passed
      * consumer.
+     *
+     * @return static
      */
-    protected function setParseHeaderValue(AbstractConsumer $consumer) : void
+    protected function setParseHeaderValue(AbstractConsumer $consumer)
     {
         $value = $this->rawValue;
         $matchp = '~' . MimeLiteralPart::MIME_PART_PATTERN . '~';
@@ -47,5 +49,6 @@ abstract class MimeEncodedHeader extends AbstractHeader
             return $this->mimeLiteralPartFactory->newInstance($matches[0]);
         }, $value);
         $this->parts = $consumer($value);
+        return $this;
     }
 }

--- a/src/Header/ParameterHeader.php
+++ b/src/Header/ParameterHeader.php
@@ -53,8 +53,10 @@ class ParameterHeader extends AbstractHeader
      * Overridden to assign ParameterParts to a map of lower-case parameter
      * names to ParameterParts.
      *
+     *
+     * @return static
      */
-    protected function setParseHeaderValue(AbstractConsumer $consumer) : void
+    protected function setParseHeaderValue(AbstractConsumer $consumer)
     {
         parent::setParseHeaderValue($consumer);
         foreach ($this->parts as $part) {
@@ -62,6 +64,7 @@ class ParameterHeader extends AbstractHeader
                 $this->parameters[\strtolower($part->getName())] = $part;
             }
         }
+        return $this;
     }
 
     /**

--- a/src/Header/Part/MimeLiteralPart.php
+++ b/src/Header/Part/MimeLiteralPart.php
@@ -154,14 +154,14 @@ class MimeLiteralPart extends LiteralPart
 
     /**
      * Adds the passed part into the languages array with the given language.
-     *
      */
-    protected function addToLanguage(string $part, ?string $language = null) : void
+    protected function addToLanguage(string $part, ?string $language = null) : self
     {
         $this->languages[] = [
             'lang' => $language,
             'value' => $part
         ];
+        return $this;
     }
 
     /**

--- a/src/Header/Part/SplitParameterToken.php
+++ b/src/Header/Part/SplitParameterToken.php
@@ -65,9 +65,8 @@ class SplitParameterToken extends HeaderPart
      * Extracts charset and language from an encoded value, setting them on the
      * current object if $index is 0 and adds the value part to the encodedParts
      * array.
-     *
      */
-    protected function extractMetaInformationAndValue(string $value, int $index) : void
+    protected function extractMetaInformationAndValue(string $value, int $index) : self
     {
         if (\preg_match('~^([^\']*)\'([^\']*)\'(.*)$~', $value, $matches)) {
             if ($index === 0) {
@@ -77,6 +76,7 @@ class SplitParameterToken extends HeaderPart
             $value = $matches[3];
         }
         $this->encodedParts[$index] = $value;
+        return $this;
     }
 
     /**

--- a/src/Header/ReceivedHeader.php
+++ b/src/Header/ReceivedHeader.php
@@ -104,8 +104,9 @@ class ReceivedHeader extends ParameterHeader
      * Overridden to assign comments to $this->comments, and the DateTime to
      * $this->date.
      *
+     * @return static
      */
-    protected function setParseHeaderValue(AbstractConsumer $consumer) : void
+    protected function setParseHeaderValue(AbstractConsumer $consumer)
     {
         parent::setParseHeaderValue($consumer);
         foreach ($this->parts as $part) {
@@ -115,6 +116,7 @@ class ReceivedHeader extends ParameterHeader
                 $this->date = $part->getDateTime();
             }
         }
+        return $this;
     }
 
     /**

--- a/src/IMessage.php
+++ b/src/IMessage.php
@@ -166,7 +166,7 @@ interface IMessage extends IMimePart
      * @param string $contentTypeCharset the charset to use as the text/plain
      *        part's content-type header charset value.
      */
-    public function setTextPart($resource, string $contentTypeCharset = 'UTF-8') : void;
+    public function setTextPart($resource, string $contentTypeCharset = 'UTF-8');
 
     /**
      * Sets the text/html part of the message to the passed $resource, either
@@ -185,7 +185,7 @@ interface IMessage extends IMimePart
      * @param string $contentTypeCharset the charset to use as the text/html
      *        part's content-type header charset value.
      */
-    public function setHtmlPart($resource, string $contentTypeCharset = 'UTF-8') : void;
+    public function setHtmlPart($resource, string $contentTypeCharset = 'UTF-8');
 
     /**
      * Removes the text/plain part of the message at the passed index if one
@@ -329,7 +329,7 @@ interface IMessage extends IMimePart
      * @param string $encoding defaults to 'base64', only applied for a mime
      *        email
      */
-    public function addAttachmentPart($resource, string $mimeType, ?string $filename = null, string $disposition = 'attachment', string $encoding = 'base64') : void;
+    public function addAttachmentPart($resource, string $mimeType, ?string $filename = null, string $disposition = 'attachment', string $encoding = 'base64');
 
     /**
      * Adds an attachment part using the passed file.
@@ -347,7 +347,7 @@ interface IMessage extends IMimePart
      * @param string $encoding defaults to 'base64', only applied for a mime
      *        email
      */
-    public function addAttachmentPartFromFile($filePath, string $mimeType, ?string $filename = null, string $disposition = 'attachment', string $encoding = 'base64') : void;
+    public function addAttachmentPartFromFile($filePath, string $mimeType, ?string $filename = null, string $disposition = 'attachment', string $encoding = 'base64');
 
     /**
      * Removes the attachment at the given index.
@@ -360,7 +360,7 @@ interface IMessage extends IMimePart
      *  - any signature part
      *
      */
-    public function removeAttachmentPart(int $index) : void;
+    public function removeAttachmentPart(int $index);
 
     /**
      * Returns a stream that can be used to read the content part of a signed
@@ -420,7 +420,7 @@ interface IMessage extends IMimePart
      * @param string $micalg The Message Integrity Check algorithm being used
      * @param string $protocol The mime-type of the signature body
      */
-    public function setAsMultipartSigned(string $micalg, string $protocol) : void;
+    public function setAsMultipartSigned(string $micalg, string $protocol);
 
     /**
      * Sets the signature body of the message to the passed $body for a
@@ -428,5 +428,5 @@ interface IMessage extends IMimePart
      *
      * @param string $body the message's hash
      */
-    public function setSignature(string $body) : void;
+    public function setSignature(string $body);
 }

--- a/src/Message.php
+++ b/src/Message.php
@@ -168,7 +168,7 @@ class Message extends MimePart implements IMessage
         return null;
     }
 
-    public function setTextPart($resource, string $charset = 'UTF-8') : void
+    public function setTextPart($resource, string $charset = 'UTF-8') : self
     {
         $this->multipartHelper
             ->setContentPartForMimeType(
@@ -177,9 +177,10 @@ class Message extends MimePart implements IMessage
                 $resource,
                 $charset
             );
+        return $this;
     }
 
-    public function setHtmlPart($resource, string $charset = 'UTF-8') : void
+    public function setHtmlPart($resource, string $charset = 'UTF-8') : self
     {
         $this->multipartHelper
             ->setContentPartForMimeType(
@@ -188,6 +189,7 @@ class Message extends MimePart implements IMessage
                 $resource,
                 $charset
             );
+        return $this;
     }
 
     public function removeTextPart(int $index = 0) : bool
@@ -250,7 +252,7 @@ class Message extends MimePart implements IMessage
         return \count($this->getAllAttachmentParts());
     }
 
-    public function addAttachmentPart($resource, string $mimeType, ?string $filename = null, string $disposition = 'attachment', string $encoding = 'base64') : void
+    public function addAttachmentPart($resource, string $mimeType, ?string $filename = null, string $disposition = 'attachment', string $encoding = 'base64') : self
     {
         $this->multipartHelper
             ->createAndAddPartForAttachment(
@@ -261,21 +263,24 @@ class Message extends MimePart implements IMessage
                 $filename,
                 $encoding
             );
+        return $this;
     }
 
-    public function addAttachmentPartFromFile($filePath, string $mimeType, ?string $filename = null, string $disposition = 'attachment', string $encoding = 'base64') : void
+    public function addAttachmentPartFromFile($filePath, string $mimeType, ?string $filename = null, string $disposition = 'attachment', string $encoding = 'base64') : self
     {
         $handle = Psr7\Utils::streamFor(\fopen($filePath, 'r'));
         if ($filename === null) {
             $filename = \basename($filePath);
         }
         $this->addAttachmentPart($handle, $mimeType, $filename, $disposition, $encoding);
+        return $this;
     }
 
-    public function removeAttachmentPart(int $index) : void
+    public function removeAttachmentPart(int $index) : self
     {
         $part = $this->getAttachmentPart($index);
         $this->removePart($part);
+        return $this;
     }
 
     public function getSignedMessageStream()
@@ -301,15 +306,17 @@ class Message extends MimePart implements IMessage
 
     }
 
-    public function setAsMultipartSigned(string $micalg, string $protocol) : void
+    public function setAsMultipartSigned(string $micalg, string $protocol) : self
     {
         $this->privacyHelper
             ->setMessageAsMultipartSigned($this, $micalg, $protocol);
+        return $this;
     }
 
-    public function setSignature(string $body) : void
+    public function setSignature(string $body) : self
     {
         $this->privacyHelper
             ->setSignature($this, $body);
+        return $this;
     }
 }

--- a/src/Message.php
+++ b/src/Message.php
@@ -168,7 +168,10 @@ class Message extends MimePart implements IMessage
         return null;
     }
 
-    public function setTextPart($resource, string $charset = 'UTF-8') : self
+    /**
+     * @return static
+     */
+    public function setTextPart($resource, string $charset = 'UTF-8')
     {
         $this->multipartHelper
             ->setContentPartForMimeType(
@@ -252,7 +255,10 @@ class Message extends MimePart implements IMessage
         return \count($this->getAllAttachmentParts());
     }
 
-    public function addAttachmentPart($resource, string $mimeType, ?string $filename = null, string $disposition = 'attachment', string $encoding = 'base64') : self
+	/**
+	 * @return static
+	 */
+    public function addAttachmentPart($resource, string $mimeType, ?string $filename = null, string $disposition = 'attachment', string $encoding = 'base64')
     {
         $this->multipartHelper
             ->createAndAddPartForAttachment(
@@ -266,7 +272,10 @@ class Message extends MimePart implements IMessage
         return $this;
     }
 
-    public function addAttachmentPartFromFile($filePath, string $mimeType, ?string $filename = null, string $disposition = 'attachment', string $encoding = 'base64') : self
+    /**
+     * @return static
+     */
+    public function addAttachmentPartFromFile($filePath, string $mimeType, ?string $filename = null, string $disposition = 'attachment', string $encoding = 'base64')
     {
         $handle = Psr7\Utils::streamFor(\fopen($filePath, 'r'));
         if ($filename === null) {
@@ -306,7 +315,10 @@ class Message extends MimePart implements IMessage
 
     }
 
-    public function setAsMultipartSigned(string $micalg, string $protocol) : self
+    /**
+     * @return static
+     */
+    public function setAsMultipartSigned(string $micalg, string $protocol)
     {
         $this->privacyHelper
             ->setMessageAsMultipartSigned($this, $micalg, $protocol);

--- a/src/Message.php
+++ b/src/Message.php
@@ -255,9 +255,9 @@ class Message extends MimePart implements IMessage
         return \count($this->getAllAttachmentParts());
     }
 
-	/**
-	 * @return static
-	 */
+    /**
+     * @return static
+     */
     public function addAttachmentPart($resource, string $mimeType, ?string $filename = null, string $disposition = 'attachment', string $encoding = 'base64')
     {
         $this->multipartHelper

--- a/src/Message/Helper/GenericHelper.php
+++ b/src/Message/Helper/GenericHelper.php
@@ -59,9 +59,8 @@ class GenericHelper extends AbstractHelper
      *
      * An exception is made for the obsolete Content-Return header, which isn't
      * isn't a MIME content field and so isn't removed.
-     *
      */
-    public function removeContentHeadersAndContent(IMimePart $part) : void
+    public function removeContentHeadersAndContent(IMimePart $part) : self
     {
         foreach ($part->getAllHeaders() as $header) {
             if ($this->isMimeContentField($header)) {
@@ -69,6 +68,7 @@ class GenericHelper extends AbstractHelper
             }
         }
         $part->detachContentStream();
+        return $this;
     }
 
     /**
@@ -141,17 +141,18 @@ class GenericHelper extends AbstractHelper
      * same position.  If $part is the IMessage, then $part can't be removed and
      * replaced, and instead $replacement's type headers are copied to $message,
      * and any children below $replacement are added directly below $message.
-     *
      */
-    public function replacePart(IMessage $message, IMimePart $part, IMimePart $replacement)
+    public function replacePart(IMessage $message, IMimePart $part, IMimePart $replacement) : self
     {
         $position = $message->removePart($replacement);
         if ($part === $message) {
             $this->movePartContentAndChildren($replacement, $message);
-            return;
+            return $this;
         }
         $parent = $part->getParent();
         $parent->addChild($replacement, $position);
         $parent->removePart($part);
+
+        return $this;
     }
 }

--- a/src/Message/Helper/MultipartHelper.php
+++ b/src/Message/Helper/MultipartHelper.php
@@ -30,7 +30,7 @@ class MultipartHelper extends AbstractHelper
     private $genericHelper;
 
     public function __construct(IMimePartFactory $mimePartFactory, IUUEncodedPartFactory $uuEncodedPartFactory, GenericHelper $genericHelper)
-	{
+    {
         parent::__construct($mimePartFactory, $uuEncodedPartFactory);
         $this->genericHelper = $genericHelper;
     }
@@ -50,9 +50,8 @@ class MultipartHelper extends AbstractHelper
     /**
      * Creates a unique mime boundary and assigns it to the passed part's
      * Content-Type header with the passed mime type.
-     *
      */
-    public function setMimeHeaderBoundaryOnPart(IMimePart $part, string $mimeType) : void
+    public function setMimeHeaderBoundaryOnPart(IMimePart $part, string $mimeType) : self
     {
         $part->setRawHeader(
             HeaderConsts::CONTENT_TYPE,
@@ -60,6 +59,7 @@ class MultipartHelper extends AbstractHelper
                 . $this->getUniqueBoundary($mimeType) . '"'
         );
         $part->notify();
+        return $this;
     }
 
     /**
@@ -68,9 +68,8 @@ class MultipartHelper extends AbstractHelper
      * If the message has content, a new part is created and added as a child of
      * the message.  The message's content and content headers are moved to the
      * new part.
-     *
      */
-    public function setMessageAsMixed(IMessage $message) : void
+    public function setMessageAsMixed(IMessage $message) : self
     {
         if ($message->hasContent()) {
             $part = $this->genericHelper->createNewContentPartFrom($message);
@@ -83,6 +82,7 @@ class MultipartHelper extends AbstractHelper
                 $att->notify();
             }
         }
+        return $this;
     }
 
     /**
@@ -91,15 +91,15 @@ class MultipartHelper extends AbstractHelper
      * If the message has content, a new part is created and added as a child of
      * the message.  The message's content and content headers are moved to the
      * new part.
-     *
      */
-    public function setMessageAsAlternative(IMessage $message) : void
+    public function setMessageAsAlternative(IMessage $message) : self
     {
         if ($message->hasContent()) {
             $part = $this->genericHelper->createNewContentPartFrom($message);
             $message->addChild($part, 0);
         }
         $this->setMimeHeaderBoundaryOnPart($message, 'multipart/alternative');
+        return $this;
     }
 
     /**
@@ -182,7 +182,7 @@ class MultipartHelper extends AbstractHelper
      * content-type equal to $exceptMimeType.  If the message is not a
      * multipart/mixed message, it is set to multipart/mixed first.
      */
-    public function moveAllNonMultiPartsToMessageExcept(IMessage $message, IMimePart $from, string $exceptMimeType) : void
+    public function moveAllNonMultiPartsToMessageExcept(IMessage $message, IMimePart $from, string $exceptMimeType) : self
     {
         $parts = $from->getAllParts(function(IMessagePart $part) use ($exceptMimeType) {
             if ($part instanceof IMimePart && $part->isMultiPart()) {
@@ -197,6 +197,7 @@ class MultipartHelper extends AbstractHelper
             $from->removePart($part);
             $message->addChild($part);
         }
+        return $this;
     }
 
     /**
@@ -366,7 +367,7 @@ class MultipartHelper extends AbstractHelper
      *
      * @param string|resource $stringOrHandle
      */
-    public function setContentPartForMimeType(IMessage $message, string $mimeType, $stringOrHandle, string $charset) : void
+    public function setContentPartForMimeType(IMessage $message, string $mimeType, $stringOrHandle, string $charset) : self
     {
         $part = ($mimeType === 'text/html') ? $message->getHtmlPart() : $message->getTextPart();
         if ($part === null) {
@@ -376,5 +377,6 @@ class MultipartHelper extends AbstractHelper
             $part->setRawHeader(HeaderConsts::CONTENT_TYPE, "$contentType;\r\n\tcharset=\"$charset\"");
         }
         $part->setContent($stringOrHandle);
+        return $this;
     }
 }

--- a/src/Message/IMessagePart.php
+++ b/src/Message/IMessagePart.php
@@ -121,7 +121,7 @@ interface IMessagePart extends SplSubject
      * @param bool $onlyIfNoCharset if true, $charsetOverride is used only if
      *        getCharset returns null.
      */
-    public function setCharsetOverride(string $charsetOverride, bool $onlyIfNoCharset = false) : void;
+    public function setCharsetOverride(string $charsetOverride, bool $onlyIfNoCharset = false);
 
     /**
      * Returns the StreamInterface for the part's content or null if the part
@@ -230,7 +230,7 @@ interface IMessagePart extends SplSubject
      *      a resource handle.
      * @param string|resource|StreamInterface $filenameResourceOrStream
      */
-    public function saveContent($filenameResourceOrStream) : void;
+    public function saveContent($filenameResourceOrStream);
 
     /**
      * Shortcut to reading stream content and assigning it to a string.  Returns
@@ -255,7 +255,7 @@ interface IMessagePart extends SplSubject
      * @param StreamInterface $stream the content
      * @param string $streamCharset the charset of $stream
      */
-    public function attachContentStream(StreamInterface $stream, string $streamCharset = MailMimeParser::DEFAULT_CHARSET) : void;
+    public function attachContentStream(StreamInterface $stream, string $streamCharset = MailMimeParser::DEFAULT_CHARSET);
 
     /**
      * Detaches the content stream.
@@ -263,7 +263,7 @@ interface IMessagePart extends SplSubject
      * @see IMessagePart::getContentStream() to get the content stream.
      * @see IMessagePart::attachContentStream() to attach a content stream.
      */
-    public function detachContentStream() : void;
+    public function detachContentStream();
 
     /**
      * Sets the content of the part to the passed string, resource, or stream.
@@ -274,7 +274,7 @@ interface IMessagePart extends SplSubject
      * @param string|resource|StreamInterface $resource the content.
      * @param string $resourceCharset the charset of the passed $resource.
      */
-    public function setContent($resource, string $resourceCharset = MailMimeParser::DEFAULT_CHARSET) : void;
+    public function setContent($resource, string $resourceCharset = MailMimeParser::DEFAULT_CHARSET);
 
     /**
      * Returns a resource handle for the string representation of this part,
@@ -368,7 +368,7 @@ interface IMessagePart extends SplSubject
      * @param string $filemode Optional filemode to open a file in (if
      *        $filenameResourceOrStream is a string)
      */
-    public function save($filenameResourceOrStream, string $filemode = 'w+') : void;
+    public function save($filenameResourceOrStream, string $filemode = 'w+');
 
     /**
      * Returns the message/part as a string, containing its headers, content and

--- a/src/Message/IMimePart.php
+++ b/src/Message/IMimePart.php
@@ -234,7 +234,7 @@ interface IMimePart extends IMultiPart
      * @param int $offset An optional offset, defaulting to '0' and therefore
      *        overriding the first header of the given $name if one exists.
      */
-    public function setRawHeader(string $name, ?string $value, int $offset = 0) : void;
+    public function setRawHeader(string $name, ?string $value, int $offset = 0);
 
     /**
      * Adds a header with the given $name and $value.
@@ -260,7 +260,7 @@ interface IMimePart extends IMultiPart
      * @param string $name The name of the header
      * @param string $value The raw value of the header.
      */
-    public function addRawHeader(string $name, string $value) : void;
+    public function addRawHeader(string $name, string $value);
 
     /**
      * Removes all headers from this part with the passed name.
@@ -273,7 +273,7 @@ interface IMimePart extends IMultiPart
      *      one with the passed name exists.
      * @param string $name The name of the header(s) to remove.
      */
-    public function removeHeader(string $name) : void;
+    public function removeHeader(string $name);
 
     /**
      * Removes a single header with the passed name (in cases where more than
@@ -289,5 +289,5 @@ interface IMimePart extends IMultiPart
      * @param int $offset Optional offset of the header to remove (defaults to
      *        0 -- the first header).
      */
-    public function removeSingleHeader(string $name, int $offset = 0) : void;
+    public function removeSingleHeader(string $name, int $offset = 0);
 }

--- a/src/Message/IUUEncodedPart.php
+++ b/src/Message/IUUEncodedPart.php
@@ -31,7 +31,7 @@ interface IUUEncodedPart extends IMessagePart
      * Sets the filename included in the uuencoded 'begin' line.
      *
      */
-    public function setFilename(string $filename) : void;
+    public function setFilename(string $filename);
 
     /**
      * Returns the file mode included in the uuencoded 'begin' line for this
@@ -42,5 +42,5 @@ interface IUUEncodedPart extends IMessagePart
     /**
      * Sets the unix file mode for the uuencoded 'begin' line.
      */
-    public function setUnixFileMode(int $mode) : void;
+    public function setUnixFileMode(int $mode);
 }

--- a/src/Message/MessagePart.php
+++ b/src/Message/MessagePart.php
@@ -93,11 +93,15 @@ abstract class MessagePart implements IMessagePart
         return null;
     }
 
-    public function setCharsetOverride(string $charsetOverride, bool $onlyIfNoCharset = false) : void
+    /**
+     * @return static
+     */
+    public function setCharsetOverride(string $charsetOverride, bool $onlyIfNoCharset = false)
     {
         if (!$onlyIfNoCharset || $this->getCharset() === null) {
             $this->charsetOverride = $charsetOverride;
         }
+        return $this;
     }
 
     public function getContentStream(string $charset = MailMimeParser::DEFAULT_CHARSET)
@@ -132,7 +136,7 @@ abstract class MessagePart implements IMessagePart
         return null;
     }
 
-    public function saveContent($filenameResourceOrStream) : void
+    public function saveContent($filenameResourceOrStream) : self
     {
         $resourceOrStream = $filenameResourceOrStream;
         if (\is_string($filenameResourceOrStream)) {
@@ -148,6 +152,7 @@ abstract class MessagePart implements IMessagePart
             // fopen call can be properly closed if it was
             $stream->detach();
         }
+        return $this;
     }
 
     public function getContent(string $charset = MailMimeParser::DEFAULT_CHARSET) : ?string
@@ -159,7 +164,7 @@ abstract class MessagePart implements IMessagePart
         return null;
     }
 
-    public function attachContentStream(StreamInterface $stream, string $streamCharset = MailMimeParser::DEFAULT_CHARSET) : void
+    public function attachContentStream(StreamInterface $stream, string $streamCharset = MailMimeParser::DEFAULT_CHARSET) : self
     {
         $ch = $this->charsetOverride ?? $this->getCharset();
         if ($ch !== null && $streamCharset !== $ch) {
@@ -168,19 +173,22 @@ abstract class MessagePart implements IMessagePart
         $this->ignoreTransferEncoding = true;
         $this->partStreamContainer->setContentStream($stream);
         $this->notify();
+        return $this;
     }
 
-    public function detachContentStream() : void
+    public function detachContentStream() : self
     {
         $this->partStreamContainer->setContentStream(null);
         $this->notify();
+        return $this;
     }
 
-    public function setContent($resource, string $charset = MailMimeParser::DEFAULT_CHARSET) : void
+    public function setContent($resource, string $charset = MailMimeParser::DEFAULT_CHARSET) : self
     {
         $stream = Utils::streamFor($resource);
         $this->attachContentStream($stream, $charset);
         // this->notify() called in attachContentStream
+        return $this;
     }
 
     public function getResourceHandle()
@@ -193,7 +201,7 @@ abstract class MessagePart implements IMessagePart
         return $this->partStreamContainer->getStream();
     }
 
-    public function save($filenameResourceOrStream, string $filemode = 'w+') : void
+    public function save($filenameResourceOrStream, string $filemode = 'w+') : self
     {
         $resourceOrStream = $filenameResourceOrStream;
         if (\is_string($filenameResourceOrStream)) {
@@ -211,6 +219,7 @@ abstract class MessagePart implements IMessagePart
             // fopen call can be properly closed if it was
             $stream->detach();
         }
+        return $this;
     }
 
     public function __toString() : string

--- a/src/Message/MessagePart.php
+++ b/src/Message/MessagePart.php
@@ -164,7 +164,10 @@ abstract class MessagePart implements IMessagePart
         return null;
     }
 
-    public function attachContentStream(StreamInterface $stream, string $streamCharset = MailMimeParser::DEFAULT_CHARSET) : self
+    /**
+     * @return static
+     */
+    public function attachContentStream(StreamInterface $stream, string $streamCharset = MailMimeParser::DEFAULT_CHARSET)
     {
         $ch = $this->charsetOverride ?? $this->getCharset();
         if ($ch !== null && $streamCharset !== $ch) {
@@ -176,14 +179,20 @@ abstract class MessagePart implements IMessagePart
         return $this;
     }
 
-    public function detachContentStream() : self
+    /**
+     * @return static
+     */
+    public function detachContentStream()
     {
         $this->partStreamContainer->setContentStream(null);
         $this->notify();
         return $this;
     }
 
-    public function setContent($resource, string $charset = MailMimeParser::DEFAULT_CHARSET) : self
+    /**
+     * @return static
+     */
+    public function setContent($resource, string $charset = MailMimeParser::DEFAULT_CHARSET)
     {
         $stream = Utils::streamFor($resource);
         $this->attachContentStream($stream, $charset);
@@ -201,7 +210,10 @@ abstract class MessagePart implements IMessagePart
         return $this->partStreamContainer->getStream();
     }
 
-    public function save($filenameResourceOrStream, string $filemode = 'w+') : self
+    /**
+     * @return static
+     */
+    public function save($filenameResourceOrStream, string $filemode = 'w+')
     {
         $resourceOrStream = $filenameResourceOrStream;
         if (\is_string($filenameResourceOrStream)) {

--- a/src/Message/MimePart.php
+++ b/src/Message/MimePart.php
@@ -300,7 +300,10 @@ class MimePart extends MultiPart implements IMimePart
         return $this;
     }
 
-    public function removeSingleHeader(string $name, int $offset = 0) : self
+    /**
+     * @return static
+     */
+    public function removeSingleHeader(string $name, int $offset = 0)
     {
         $this->headerContainer->remove($name, $offset);
         $this->notify();

--- a/src/Message/MimePart.php
+++ b/src/Message/MimePart.php
@@ -270,27 +270,40 @@ class MimePart extends MultiPart implements IMimePart
         return $defaultValue;
     }
 
-    public function setRawHeader(string $name, ?string $value, int $offset = 0) : void
+    /**
+     * @return static
+     */
+    public function setRawHeader(string $name, ?string $value, int $offset = 0)
     {
         $this->headerContainer->set($name, $value, $offset);
         $this->notify();
+        return $this;
     }
 
-    public function addRawHeader(string $name, string $value) : void
+    /**
+     * @return static
+     */
+    public function addRawHeader(string $name, string $value)
     {
         $this->headerContainer->add($name, $value);
         $this->notify();
+        return $this;
     }
 
-    public function removeHeader(string $name) : void
+    /**
+     * @return static
+     */
+    public function removeHeader(string $name)
     {
         $this->headerContainer->removeAll($name);
         $this->notify();
+        return $this;
     }
 
-    public function removeSingleHeader(string $name, int $offset = 0) : void
+    public function removeSingleHeader(string $name, int $offset = 0) : self
     {
         $this->headerContainer->remove($name, $offset);
         $this->notify();
+        return $this;
     }
 }

--- a/src/Message/PartHeaderContainer.php
+++ b/src/Message/PartHeaderContainer.php
@@ -238,16 +238,17 @@ class PartHeaderContainer implements IteratorAggregate
      * @param string $value
      * @param int $offset
      */
-    public function set($name, $value, $offset = 0)
+    public function set($name, $value, $offset = 0) : self
     {
         $s = $this->headerFactory->getNormalizedHeaderName($name);
         if (!isset($this->headerMap[$s][$offset])) {
             $this->add($name, $value);
-            return;
+            return $this;
         }
         $i = $this->headerMap[$s][$offset];
         $this->headers[$i] = [$name, $value];
         $this->headerObjects[$i] = null;
+        return $this;
     }
 
     /**

--- a/src/Message/PartStreamContainer.php
+++ b/src/Message/PartStreamContainer.php
@@ -169,7 +169,7 @@ class PartStreamContainer
      *
      * @param string $transferEncoding
      */
-    protected function attachTransferEncodingFilter(?string $transferEncoding) : void
+    protected function attachTransferEncodingFilter(?string $transferEncoding) : self
     {
         if ($this->decodedStream !== null) {
             $this->encoding['type'] = $transferEncoding;
@@ -189,6 +189,7 @@ class PartStreamContainer
                 $this->decodedStream = new CachingStream($assign);
             }
         }
+        return $this;
     }
 
     /**
@@ -198,7 +199,7 @@ class PartStreamContainer
      * @param string $fromCharset the character set the content is encoded in
      * @param string $toCharset the target encoding to return
      */
-    protected function attachCharsetFilter(string $fromCharset, string $toCharset) : void
+    protected function attachCharsetFilter(string $fromCharset, string $toCharset) : self
     {
         if ($this->charsetStream !== null) {
             $this->charsetStream = new CachingStream($this->streamFactory->newCharsetStream(
@@ -209,12 +210,13 @@ class PartStreamContainer
             $this->charset['from'] = $fromCharset;
             $this->charset['to'] = $toCharset;
         }
+        return $this;
     }
 
     /**
      * Resets just the charset stream, and rewinds the decodedStream.
      */
-    private function resetCharsetStream() : void
+    private function resetCharsetStream() : self
     {
         $this->charset = [
             'from' => null,
@@ -223,6 +225,7 @@ class PartStreamContainer
         ];
         $this->decodedStream->rewind();
         $this->charsetStream = $this->decodedStream;
+        return $this;
     }
 
     /**

--- a/src/Message/UUEncodedPart.php
+++ b/src/Message/UUEncodedPart.php
@@ -53,10 +53,11 @@ class UUEncodedPart extends NonMimePart implements IUUEncodedPart
         return $this->filename;
     }
 
-    public function setFilename(string $filename) : void
+    public function setFilename(string $filename) : self
     {
         $this->filename = $filename;
         $this->notify();
+        return $this;
     }
 
     /**
@@ -112,9 +113,10 @@ class UUEncodedPart extends NonMimePart implements IUUEncodedPart
         return $this->mode;
     }
 
-    public function setUnixFileMode(int $mode) : void
+    public function setUnixFileMode(int $mode) : self
     {
         $this->mode = $mode;
         $this->notify();
+        return $this;
     }
 }

--- a/src/Message/UUEncodedPart.php
+++ b/src/Message/UUEncodedPart.php
@@ -53,7 +53,10 @@ class UUEncodedPart extends NonMimePart implements IUUEncodedPart
         return $this->filename;
     }
 
-    public function setFilename(string $filename) : self
+    /**
+     * @return static
+     */
+    public function setFilename(string $filename)
     {
         $this->filename = $filename;
         $this->notify();
@@ -113,7 +116,10 @@ class UUEncodedPart extends NonMimePart implements IUUEncodedPart
         return $this->mode;
     }
 
-    public function setUnixFileMode(int $mode) : self
+    /**
+     * @return static
+     */
+    public function setUnixFileMode(int $mode)
     {
         $this->mode = $mode;
         $this->notify();

--- a/src/Parser/AbstractParser.php
+++ b/src/Parser/AbstractParser.php
@@ -57,9 +57,13 @@ abstract class AbstractParser implements IParser
         $this->partBuilderFactory = $partBuilderFactory;
     }
 
-    public function setParserManager(ParserManager $pm) : void
+    /**
+     * @return static
+     */
+    public function setParserManager(ParserManager $pm)
     {
         $this->parserManager = $pm;
+        return $this;
     }
 
     public function getParserMessageProxyFactory()

--- a/src/Parser/HeaderParser.php
+++ b/src/Parser/HeaderParser.php
@@ -23,12 +23,13 @@ class HeaderParser
      * @param string $header the header line
      * @param PartHeaderContainer $headerContainer the container
      */
-    private function addRawHeaderToPart(string $header, PartHeaderContainer $headerContainer) : void
+    private function addRawHeaderToPart(string $header, PartHeaderContainer $headerContainer) : self
     {
         if ($header !== '' && \strpos($header, ':') !== false) {
             $a = \explode(':', $header, 2);
             $headerContainer->add($a[0], \trim($a[1]));
         }
+        return $this;
     }
 
     /**
@@ -38,7 +39,7 @@ class HeaderParser
      * @param resource $handle The resource handle to read from.
      * @param PartHeaderContainer $container the container to add headers to.
      */
-    public function parse($handle, PartHeaderContainer $container) : void
+    public function parse($handle, PartHeaderContainer $container) : self
     {
         $header = '';
         do {
@@ -51,5 +52,6 @@ class HeaderParser
             }
             $header .= \rtrim($line, "\r\n");
         } while ($header !== '');
+        return $this;
     }
 }

--- a/src/Parser/IParser.php
+++ b/src/Parser/IParser.php
@@ -25,7 +25,7 @@ interface IParser
      *
      * @param ParserManager $pm The ParserManager to set.
      */
-    public function setParserManager(ParserManager $pm) : void;
+    public function setParserManager(ParserManager $pm);
 
     /**
      * Called by the ParserManager to determine if the passed PartBuilder is a
@@ -69,7 +69,7 @@ interface IParser
      * message has been reached $proxy->setEof() should be called in addition to
      * setStreamContentAndPartEndPos().
      */
-    public function parseContent(ParserPartProxy $proxy) : void;
+    public function parseContent(ParserPartProxy $proxy);
 
     /**
      * Performs read operations to read children from the passed $proxy, using

--- a/src/Parser/MimeParser.php
+++ b/src/Parser/MimeParser.php
@@ -93,7 +93,7 @@ class MimeParser extends AbstractParser
      * were read.
      *
      */
-    private function findContentBoundary(ParserMimePartProxy $proxy) : void
+    private function findContentBoundary(ParserMimePartProxy $proxy) : self
     {
         $handle = $proxy->getMessageResourceHandle();
         // last separator before a boundary belongs to the boundary, and is not
@@ -103,17 +103,22 @@ class MimeParser extends AbstractParser
             $line = $this->readBoundaryLine($handle, $proxy);
             if (\substr($line, 0, 2) === '--' && $proxy->setEndBoundaryFound($line)) {
                 $proxy->setStreamPartAndContentEndPos($endPos);
-                return;
+                return $this;
             }
         }
         $proxy->setStreamPartAndContentEndPos(\ftell($handle));
         $proxy->setEof();
+        return $this;
     }
 
-    public function parseContent(ParserPartProxy $proxy) : void
+    /**
+     * @return static
+     */
+    public function parseContent(ParserPartProxy $proxy)
     {
         $proxy->setStreamContentStartPos($proxy->getMessageResourceHandlePos());
         $this->findContentBoundary($proxy);
+        return $this;
     }
 
     /**

--- a/src/Parser/ParserManager.php
+++ b/src/Parser/ParserManager.php
@@ -36,12 +36,13 @@ class ParserManager
      * calling $parser->setParserManager($this) on each one.
      *
      */
-    public function setParsers(array $parsers) : void
+    public function setParsers(array $parsers) : self
     {
         foreach ($parsers as $parser) {
             $parser->setParserManager($this);
         }
         $this->parsers = $parsers;
+        return $this;
     }
 
     /**
@@ -50,10 +51,11 @@ class ParserManager
      *
      * @param IParser $parser The parser to add.
      */
-    public function prependParser(IParser $parser) : void
+    public function prependParser(IParser $parser) : self
     {
         $parser->setParserManager($this);
         \array_unshift($this->parsers, $parser);
+        return $this;
     }
 
     /**

--- a/src/Parser/Part/ParserPartChildrenContainer.php
+++ b/src/Parser/Part/ParserPartChildrenContainer.php
@@ -36,7 +36,6 @@ class ParserPartChildrenContainer extends PartChildrenContainer
         $this->parserProxy = $parserProxy;
     }
 
-
     public function offsetExists($offset) : bool
     {
         $exists = parent::offsetExists($offset);

--- a/src/Parser/Part/ParserPartStreamContainer.php
+++ b/src/Parser/Part/ParserPartStreamContainer.php
@@ -76,7 +76,7 @@ class ParserPartStreamContainer extends PartStreamContainer implements SplObserv
      * Requests content from the parser if not previously requested, and calls
      * PartStreamContainer::setContentStream().
      */
-    protected function requestParsedContentStream() : void
+    protected function requestParsedContentStream() : self
     {
         if (!$this->contentParseRequested) {
             $this->contentParseRequested = true;
@@ -85,6 +85,7 @@ class ParserPartStreamContainer extends PartStreamContainer implements SplObserv
                 $this->parserProxy
             ));
         }
+        return $this;
     }
 
     /**
@@ -92,7 +93,7 @@ class ParserPartStreamContainer extends PartStreamContainer implements SplObserv
      * $this->parsedStream to the original parsed stream (or a limited part of
      * it corresponding to the current part this stream container belongs to).
      */
-    protected function requestParsedStream() : void
+    protected function requestParsedStream() : self
     {
         if ($this->parsedStream === null) {
             $this->parserProxy->parseAll();
@@ -103,6 +104,7 @@ class ParserPartStreamContainer extends PartStreamContainer implements SplObserv
                 $this->detachParsedStream = ($this->parsedStream->getMetadata('mmp-detached-stream') === true);
             }
         }
+        return $this;
     }
 
     public function hasContent() : bool
@@ -123,13 +125,14 @@ class ParserPartStreamContainer extends PartStreamContainer implements SplObserv
         return parent::getBinaryContentStream($transferEncoding);
     }
 
-    public function setContentStream(?StreamInterface $contentStream = null) : void
+    public function setContentStream(?StreamInterface $contentStream = null) : self
     {
         // has to be overridden because requestParsedContentStream calls
         // parent::setContentStream as well, so needs to be parsed before
         // overriding the contentStream with a manual 'set'.
         $this->requestParsedContentStream();
         parent::setContentStream($contentStream);
+        return $this;
     }
 
     public function getStream()

--- a/src/Parser/Part/UUEncodedPartHeaderContainer.php
+++ b/src/Parser/Part/UUEncodedPartHeaderContainer.php
@@ -40,9 +40,10 @@ class UUEncodedPartHeaderContainer extends PartHeaderContainer
     /**
      * Sets the unix file mode for the uuencoded 'begin' line.
      */
-    public function setUnixFileMode(int $mode) : void
+    public function setUnixFileMode(int $mode) : self
     {
         $this->mode = $mode;
+        return $this;
     }
 
     /**
@@ -59,8 +60,9 @@ class UUEncodedPartHeaderContainer extends PartHeaderContainer
     /**
      * Sets the filename included in the uuencoded 'begin' line.
      */
-    public function setFilename(string $filename) : void
+    public function setFilename(string $filename) : self
     {
         $this->filename = $filename;
+        return $this;
     }
 }

--- a/src/Parser/Part/UUEncodedPartHeaderContainer.php
+++ b/src/Parser/Part/UUEncodedPartHeaderContainer.php
@@ -39,8 +39,8 @@ class UUEncodedPartHeaderContainer extends PartHeaderContainer
 
     /**
      * Sets the unix file mode for the uuencoded 'begin' line.
-	 *
-	 * @return static
+     *
+     * @return static
      */
     public function setUnixFileMode(int $mode)
     {
@@ -60,8 +60,8 @@ class UUEncodedPartHeaderContainer extends PartHeaderContainer
     }
 
     /**
-	 * Sets the filename included in the uuencoded 'begin' line.
-	 *
+     * Sets the filename included in the uuencoded 'begin' line.
+     *
      * @return static
      */
     public function setFilename(string $filename)

--- a/src/Parser/Part/UUEncodedPartHeaderContainer.php
+++ b/src/Parser/Part/UUEncodedPartHeaderContainer.php
@@ -39,8 +39,10 @@ class UUEncodedPartHeaderContainer extends PartHeaderContainer
 
     /**
      * Sets the unix file mode for the uuencoded 'begin' line.
+	 *
+	 * @return static
      */
-    public function setUnixFileMode(int $mode) : self
+    public function setUnixFileMode(int $mode)
     {
         $this->mode = $mode;
         return $this;
@@ -58,9 +60,11 @@ class UUEncodedPartHeaderContainer extends PartHeaderContainer
     }
 
     /**
-     * Sets the filename included in the uuencoded 'begin' line.
+	 * Sets the filename included in the uuencoded 'begin' line.
+	 *
+     * @return static
      */
-    public function setFilename(string $filename) : self
+    public function setFilename(string $filename)
     {
         $this->filename = $filename;
         return $this;

--- a/src/Parser/PartBuilder.php
+++ b/src/Parser/PartBuilder.php
@@ -199,10 +199,12 @@ class PartBuilder
      * Sets the byte offset start position of the part in the raw message
      * stream.
      *
+     * @return static
      */
-    public function setStreamPartStartPos(int $streamPartStartPos) : void
+    public function setStreamPartStartPos(int $streamPartStartPos)
     {
         $this->streamPartStartPos = $streamPartStartPos;
+        return $this;
     }
 
     /**
@@ -210,34 +212,40 @@ class PartBuilder
      * and also calls its parent's setParentStreamPartEndPos to expand to parent
      * PartBuilders.
      *
+     * @return static
      */
-    public function setStreamPartEndPos(int $streamPartEndPos) : void
+    public function setStreamPartEndPos(int $streamPartEndPos)
     {
         $this->streamPartEndPos = $streamPartEndPos;
         if ($this->parent !== null) {
             $this->parent->setStreamPartEndPos($streamPartEndPos);
         }
+        return $this;
     }
 
     /**
      * Sets the byte offset start position of the content in the raw message
      * stream.
      *
+     * @return static
      */
-    public function setStreamContentStartPos(int $streamContentStartPos) : void
+    public function setStreamContentStartPos(int $streamContentStartPos)
     {
         $this->streamContentStartPos = $streamContentStartPos;
+        return $this;
     }
 
     /**
      * Sets the byte offset end position of the content and part in the raw
      * message stream.
      *
+     * @return static
      */
-    public function setStreamPartAndContentEndPos(int $streamContentEndPos) : void
+    public function setStreamPartAndContentEndPos(int $streamContentEndPos)
     {
         $this->streamContentEndPos = $streamContentEndPos;
         $this->setStreamPartEndPos($streamContentEndPos);
+        return $this;
     }
 
     /**

--- a/src/Parser/Proxy/ParserMessageProxy.php
+++ b/src/Parser/Proxy/ParserMessageProxy.php
@@ -28,8 +28,12 @@ class ParserMessageProxy extends ParserMimePartProxy
         return $this->lastLineEndingLength;
     }
 
-    public function setLastLineEndingLength(int $lastLineEndingLength) : void
+    /**
+     * @return static
+     */
+    public function setLastLineEndingLength(int $lastLineEndingLength)
     {
         $this->lastLineEndingLength = $lastLineEndingLength;
+        return $this;
     }
 }

--- a/src/Parser/Proxy/ParserMimePartProxy.php
+++ b/src/Parser/Proxy/ParserMimePartProxy.php
@@ -57,21 +57,22 @@ class ParserMimePartProxy extends ParserPartProxy
      * Ensures that the last child added to this part is fully parsed (content
      * and children).
      */
-    protected function ensureLastChildParsed() : void
+    protected function ensureLastChildParsed() : self
     {
         if ($this->lastAddedChild !== null) {
             $this->lastAddedChild->parseAll();
         }
+        return $this;
     }
 
     /**
      * Parses the next child of this part and adds it to the 'stack' of
      * children.
      */
-    protected function parseNextChild() : void
+    protected function parseNextChild() : self
     {
         if ($this->allChildrenParsed) {
-            return;
+            return $this;
         }
         $this->parseContent();
         $this->ensureLastChildParsed();
@@ -82,6 +83,7 @@ class ParserMimePartProxy extends ParserPartProxy
         } else {
             $this->allChildrenParsed = true;
         }
+        return $this;
     }
 
     /**
@@ -102,13 +104,15 @@ class ParserMimePartProxy extends ParserPartProxy
 
     /**
      * Parses all content and children for this part.
+     * @return static
      */
-    public function parseAll() : void
+    public function parseAll()
     {
         $this->parseContent();
         while (!$this->allChildrenParsed) {
             $this->parseNextChild();
         }
+        return $this;
     }
 
     /**
@@ -190,13 +194,16 @@ class ParserMimePartProxy extends ParserPartProxy
      * Called once EOF is reached while reading content.  The method sets the
      * flag used by isParentBoundaryFound() to true on this part and all parent
      * parts.
+     *
+     * @return static
      */
-    public function setEof() : void
+    public function setEof() : self
     {
         $this->parentBoundaryFound = true;
         if ($this->getParent() !== null) {
             $this->getParent()->setEof();
         }
+        return $this;
     }
 
     /**
@@ -208,10 +215,12 @@ class ParserMimePartProxy extends ParserPartProxy
      * which must eventually reach a ParserMessageProxy which actually stores
      * the length.
      *
+     * @return static
      */
-    public function setLastLineEndingLength(int $length) : void
+    public function setLastLineEndingLength(int $length)
     {
         $this->getParent()->setLastLineEndingLength($length);
+        return $this;
     }
 
     /**

--- a/src/Parser/Proxy/ParserNonMimeMessageProxy.php
+++ b/src/Parser/Proxy/ParserNonMimeMessageProxy.php
@@ -72,36 +72,39 @@ class ParserNonMimeMessageProxy extends ParserMessageProxy
      * Sets the next part's start position within the message's raw stream.
      *
      */
-    public function setNextPartStart(int $nextPartStart) : void
+    public function setNextPartStart(int $nextPartStart) : self
     {
         $this->nextPartStart = $nextPartStart;
+        return $this;
     }
 
     /**
      * Sets the next part's unix file mode from its 'begin' line.
-     *
      */
-    public function setNextPartMode(int $nextPartMode) : void
+    public function setNextPartMode(int $nextPartMode) : self
     {
         $this->nextPartMode = $nextPartMode;
+        return $this;
     }
 
     /**
      * Sets the next part's filename from its 'begin' line.
      *
      */
-    public function setNextPartFilename(string $nextPartFilename) : void
+    public function setNextPartFilename(string $nextPartFilename) : self
     {
         $this->nextPartFilename = $nextPartFilename;
+        return $this;
     }
 
     /**
      * Sets the next part start position, file mode, and filename to null
      */
-    public function clearNextPart() : void
+    public function clearNextPart() : self
     {
         $this->nextPartStart = null;
         $this->nextPartMode = null;
         $this->nextPartFilename = null;
+        return $this;
     }
 }

--- a/src/Parser/Proxy/ParserPartProxy.php
+++ b/src/Parser/Proxy/ParserPartProxy.php
@@ -48,9 +48,10 @@ abstract class ParserPartProxy extends PartBuilder
      *
      * @param IMessagePart $part The part
      */
-    public function setPart(IMessagePart $part) : void
+    public function setPart(IMessagePart $part) : self
     {
         $this->part = $part;
+        return $this;
     }
 
     /**
@@ -70,12 +71,15 @@ abstract class ParserPartProxy extends PartBuilder
      *
      * The method first checks to see if the content has already been parsed,
      * and is safe to call multiple times.
+     *
+     * @return static
      */
-    public function parseContent() : void
+    public function parseContent()
     {
         if (!$this->isContentParsed()) {
             $this->parser->parseContent($this);
         }
+        return $this;
     }
 
     /**
@@ -83,10 +87,13 @@ abstract class ParserPartProxy extends PartBuilder
      *
      * For ParserPartProxy, this is just content, but sub-classes may override
      * this to parse all children as well for example.
-     * .     */
-    public function parseAll() : void
+     *
+     * @return static
+     */
+    public function parseAll()
     {
         $this->parseContent();
+        return $this;
     }
 
     public function getParent()
@@ -134,24 +141,40 @@ abstract class ParserPartProxy extends PartBuilder
         return $this->partBuilder->getStreamContentLength();
     }
 
-    public function setStreamPartStartPos(int $streamPartStartPos) : void
+    /**
+     * @return static
+     */
+    public function setStreamPartStartPos(int $streamPartStartPos)
     {
         $this->partBuilder->setStreamPartStartPos($streamPartStartPos);
+        return $this;
     }
 
-    public function setStreamPartEndPos(int $streamPartEndPos) : void
+    /**
+     * @return static
+     */
+    public function setStreamPartEndPos(int $streamPartEndPos)
     {
         $this->partBuilder->setStreamPartEndPos($streamPartEndPos);
+        return $this;
     }
 
-    public function setStreamContentStartPos(int $streamContentStartPos) : void
+    /**
+     * @return static
+     */
+    public function setStreamContentStartPos(int $streamContentStartPos)
     {
         $this->partBuilder->setStreamContentStartPos($streamContentStartPos);
+        return $this;
     }
 
-    public function setStreamPartAndContentEndPos(int $streamContentEndPos) : void
+    /**
+     * @return static
+     */
+    public function setStreamPartAndContentEndPos(int $streamContentEndPos)
     {
         $this->partBuilder->setStreamPartAndContentEndPos($streamContentEndPos);
+        return $this;
     }
 
     public function isContentParsed() : ?bool

--- a/src/Parser/Proxy/ParserUUEncodedPartProxy.php
+++ b/src/Parser/Proxy/ParserUUEncodedPartProxy.php
@@ -66,11 +66,11 @@ class ParserUUEncodedPartProxy extends ParserPartProxy
      * As this is a message-wide setting, ParserUUEncodedPartProxy calls
      * setNextPartStart() on its parent (a ParserNonMimeMessageProxy, which
      * stores/returns this information).
-     *
      */
-    public function setNextPartStart(int $nextPartStart) : void
+    public function setNextPartStart(int $nextPartStart) : self
     {
         $this->getParent()->setNextPartStart($nextPartStart);
+        return $this;
     }
 
     /**
@@ -79,11 +79,11 @@ class ParserUUEncodedPartProxy extends ParserPartProxy
      * As this is a message-wide setting, ParserUUEncodedPartProxy calls
      * setNextPartMode() on its parent (a ParserNonMimeMessageProxy, which
      * stores/returns this information).
-     *
      */
-    public function setNextPartMode(int $nextPartMode) : void
+    public function setNextPartMode(int $nextPartMode) : self
     {
         $this->getParent()->setNextPartMode($nextPartMode);
+        return $this;
     }
 
     /**
@@ -92,11 +92,11 @@ class ParserUUEncodedPartProxy extends ParserPartProxy
      * As this is a message-wide setting, ParserUUEncodedPartProxy calls
      * setNextPartFilename() on its parent (a ParserNonMimeMessageProxy, which
      * stores/returns this information).
-     *
      */
-    public function setNextPartFilename(string $nextPartFilename) : void
+    public function setNextPartFilename(string $nextPartFilename) : self
     {
         $this->getParent()->setNextPartFilename($nextPartFilename);
+        return $this;
     }
 
     /**

--- a/src/Stream/HeaderStream.php
+++ b/src/Stream/HeaderStream.php
@@ -80,14 +80,14 @@ class HeaderStream implements SplObserver, StreamInterface
 
     /**
      * Writes out headers for $this->part and follows them with an empty line.
-     *
      */
-    public function writePartHeadersTo(StreamInterface $stream) : void
+    public function writePartHeadersTo(StreamInterface $stream) : self
     {
         foreach ($this->getPartHeadersIterator() as $header) {
             $stream->write("{$header[0]}: {$header[1]}\r\n");
         }
         $stream->write("\r\n");
+        return $this;
     }
 
     /**

--- a/src/Stream/MessagePartStream.php
+++ b/src/Stream/MessagePartStream.php
@@ -126,9 +126,8 @@ class MessagePartStream implements SplObserver, StreamInterface
     /**
      * Writes out the content portion of the attached mime part to the passed
      * $stream.
-     *
      */
-    private function writePartContentTo(StreamInterface $stream) : void
+    private function writePartContentTo(StreamInterface $stream) : self
     {
         $contentStream = $this->part->getContentStream();
         if ($contentStream !== null) {
@@ -138,6 +137,7 @@ class MessagePartStream implements SplObserver, StreamInterface
             Psr7\Utils::copyToStream($contentStream, $cs);
             $cs->close();
         }
+        return $this;
     }
 
     /**


### PR DESCRIPTION
* Added return $this; to all methods that did not return anything.
* Added return type of self for most methods.  Only PHP 7.4 and higher support a return type of static, which is technically better.
* Removed return type of void on proxies and other class hierarchies that are not supported by PHP 7.1, but they still return $this.