### PR TITLE
Fix: README.md example to get person name from TO header

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ echo $message->getHeaderValue(HeaderConsts::SUBJECT);  // The email's subject
 echo $message
     ->getHeader(HeaderConsts::TO)                      // also AddressHeader
     ->getAddresses()[0]                                // AddressPart
-    ->getName();                                       // Person Name
+    ->getPersonName();                                 // Person Name
 echo $message
     ->getHeader(HeaderConsts::CC)                      // also AddressHeader
     ->getAddresses()[0]                                // AddressPart


### PR DESCRIPTION
@zbateson Thank you for a very useful package!

This pull request fixes a minor error in the README.md example to get the person name from the TO header.