### PR TITLE
Added getAddresses to IHeader.php

### DIFF
--- a/src/Header/IHeader.php
+++ b/src/Header/IHeader.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of the ZBateson\MailMimeParser project.
  *
@@ -26,6 +27,14 @@ interface IHeader
      * @return IHeaderPart[] The array of parts.
      */
     public function getParts() : array;
+
+    /**
+     * Returns all address parts in the header including any addresses that are
+     * in groups (lists).
+     *
+     * @return AddressPart[] The addresses.
+     */
+    public function getAddresses() : array;
 
     /**
      * Returns the parsed 'value' of the header.


### PR DESCRIPTION
phpstan is complaining about method getAddresses:

` Cannot call method getAddresses() on ZBateson\MailMimeParser\Header\IHeader`

Checked IHeader.php and the interface for getAddresses is missing so phpstan complained correctly. Added the getAddresses method to the interface file and phpstan is happy now :-)