### PR TITLE
Fixed some deprecation messages

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -92,6 +92,8 @@ class Container extends PimpleContainer
      *
      * @param string | int $id
      *
+     * @return mixed The value of the parameter or an object
+     *
      * @throws UnknownIdentifierException
      */
     #[\ReturnTypeWillChange]

--- a/src/Message/PartChildrenContainer.php
+++ b/src/Message/PartChildrenContainer.php
@@ -128,6 +128,9 @@ class PartChildrenContainer implements ArrayAccess, RecursiveIterator
         return isset($this->children[$offset]);
     }
 
+    /**
+     * @return mixed
+     */
     #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {


### PR DESCRIPTION
Fixed the following two deprecation messages, which are reported by Symfony's deprecation helper:

>   1x: Method "Pimple\Container::offsetGet()" might add "mixed" as a native return type declaration in the future. Do the same in child class "ZBateson\MailMimeParser\Container" now to avoid errors or add an explicit @return annotation to suppress this message.
> 
>  1x: Method "ArrayAccess::offsetGet()" might add "mixed" as a native return type declaration in the future. Do the same in implementation "ZBateson\MailMimeParser\Message\PartChildrenContainer" now to avoid errors or add an explicit @return annotation to suppress this message.

The return annotations were already added by #197, but reverted again with commit c1c4b6857cc35ca4b3be19e17d86a811d9296619 (PHPCSFixer).