### PR TITLE
Replace global DI library functions with corresponding objects for PRS-4 compliance

### DIFF
--- a/src/di_config.php
+++ b/src/di_config.php
@@ -5,6 +5,8 @@
  * @license http://opensource.org/licenses/bsd-license.php BSD
  */
 
+use DI\Definition\Helper\AutowireDefinitionHelper;
+use DI\Definition\Reference;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use ZBateson\MailMimeParser\Header\Consumer\Received\DomainConsumerService;
@@ -16,47 +18,47 @@ use ZBateson\MailMimeParser\Parser\Part\ParserPartStreamContainerFactory;
 use ZBateson\MailMimeParser\Stream\StreamFactory;
 
 return [
-    LoggerInterface::class => DI\autowire(NullLogger::class),
+    LoggerInterface::class => new AutowireDefinitionHelper(NullLogger::class),
 
     // only affects reading part content, not for instance decoding mime encoded
     // header parts
     'throwExceptionReadingPartContentFromUnsupportedCharsets' => false,
 
-    'fromDomainConsumerService' => DI\autowire(DomainConsumerService::class)
+    'fromDomainConsumerService' => (new AutowireDefinitionHelper(DomainConsumerService::class))
         ->constructorParameter('partName', 'from'),
-    'byDomainConsumerService' => DI\autowire(DomainConsumerService::class)
+    'byDomainConsumerService' => (new AutowireDefinitionHelper(DomainConsumerService::class))
         ->constructorParameter('partName', 'by'),
-    'viaGenericReceivedConsumerService' => DI\autowire(GenericReceivedConsumerService::class)
+    'viaGenericReceivedConsumerService' => (new AutowireDefinitionHelper(GenericReceivedConsumerService::class))
         ->constructorParameter('partName', 'via'),
-    'withGenericReceivedConsumerService' => DI\autowire(GenericReceivedConsumerService::class)
+    'withGenericReceivedConsumerService' => (new AutowireDefinitionHelper(GenericReceivedConsumerService::class))
         ->constructorParameter('partName', 'with'),
-    'idGenericReceivedConsumerService' => DI\autowire(GenericReceivedConsumerService::class)
+    'idGenericReceivedConsumerService' => (new AutowireDefinitionHelper(GenericReceivedConsumerService::class))
         ->constructorParameter('partName', 'id'),
-    'forGenericReceivedConsumerService' => DI\autowire(GenericReceivedConsumerService::class)
+    'forGenericReceivedConsumerService' => (new AutowireDefinitionHelper(GenericReceivedConsumerService::class))
         ->constructorParameter('partName', 'for'),
-    ReceivedConsumerService::class => DI\autowire()
+    ReceivedConsumerService::class => (new AutowireDefinitionHelper())
         ->constructor(
-            fromDomainConsumerService: DI\get('fromDomainConsumerService'),
-            byDomainConsumerService: DI\get('byDomainConsumerService'),
-            viaGenericReceivedConsumerService: DI\get('viaGenericReceivedConsumerService'),
-            withGenericReceivedConsumerService: DI\get('withGenericReceivedConsumerService'),
-            idGenericReceivedConsumerService: DI\get('idGenericReceivedConsumerService'),
-            forGenericReceivedConsumerService: DI\get('forGenericReceivedConsumerService')
+            fromDomainConsumerService: new Reference('fromDomainConsumerService'),
+            byDomainConsumerService: new Reference('byDomainConsumerService'),
+            viaGenericReceivedConsumerService: new Reference('viaGenericReceivedConsumerService'),
+            withGenericReceivedConsumerService: new Reference('withGenericReceivedConsumerService'),
+            idGenericReceivedConsumerService: new Reference('idGenericReceivedConsumerService'),
+            forGenericReceivedConsumerService: new Reference('forGenericReceivedConsumerService')
         ),
-    PartStreamContainer::class => DI\autowire()
+    PartStreamContainer::class => (new AutowireDefinitionHelper())
         ->constructor(
-            throwExceptionReadingPartContentFromUnsupportedCharsets: DI\get('throwExceptionReadingPartContentFromUnsupportedCharsets')
+            throwExceptionReadingPartContentFromUnsupportedCharsets: new Reference('throwExceptionReadingPartContentFromUnsupportedCharsets')
         ),
-    PartStreamContainerFactory::class => DI\autowire()
+    PartStreamContainerFactory::class => (new AutowireDefinitionHelper())
         ->constructor(
-            throwExceptionReadingPartContentFromUnsupportedCharsets: DI\get('throwExceptionReadingPartContentFromUnsupportedCharsets')
+            throwExceptionReadingPartContentFromUnsupportedCharsets: new Reference('throwExceptionReadingPartContentFromUnsupportedCharsets')
         ),
-    ParserPartStreamContainerFactory::class => DI\autowire()
+    ParserPartStreamContainerFactory::class => (new AutowireDefinitionHelper())
         ->constructor(
-            throwExceptionReadingPartContentFromUnsupportedCharsets: DI\get('throwExceptionReadingPartContentFromUnsupportedCharsets')
+            throwExceptionReadingPartContentFromUnsupportedCharsets: new Reference('throwExceptionReadingPartContentFromUnsupportedCharsets')
         ),
-    StreamFactory::class => DI\autowire()
+    StreamFactory::class => (new AutowireDefinitionHelper())
         ->constructor(
-            throwExceptionReadingPartContentFromUnsupportedCharsets: DI\get('throwExceptionReadingPartContentFromUnsupportedCharsets')
+            throwExceptionReadingPartContentFromUnsupportedCharsets: new Reference('throwExceptionReadingPartContentFromUnsupportedCharsets')
         ),
 ];


### PR DESCRIPTION
This PR makes the library fully PSR-4 compliant.

The [php-di/php-di](https://packagist.org/packages/php-di/php-di) library supports global functions for various setup configurations.  The problem is global functions are not PRS-4 compliant, so using a [super fast and minimal memory footprint autoloader](https://blog.phpfui.com/benchmarking-php-autoloaders) fails.

The solution is simple, use the corresponding classes called by the [global functions](https://github.com/PHP-DI/PHP-DI/blob/master/src/functions.php).  It turns out the php-di library does not use these global functions, and it is considered bad form to use global functions, as they are not PSR-4 compliant. Guzzle has recently depreciated [global functions](https://github.com/guzzle/guzzle/blob/7.8/src/functions.php) for example.