### PR TITLE
Remove dependency on \Composer\Autoload\ClassLoader

### DIFF
--- a/src/MailMimeParser.php
+++ b/src/MailMimeParser.php
@@ -115,6 +115,9 @@ class MailMimeParser
      */
     private static function discoverPluginConfigs() : array
     {
+        if (! \class_exists(\Composer\Autoload\ClassLoader::class)) {
+            return [];
+        }
         $autoloadFile = (new \ReflectionClass(\Composer\Autoload\ClassLoader::class))->getFileName();
         if ($autoloadFile === false) {
             return [];


### PR DESCRIPTION
If you are not using Composer for autoloading (because it is slow and bloated, see [WFA](https://blog.phpfui.com/benchmarking-php-autoloaders)), then the following code produces an error:

```
$autoloadFile = (new \ReflectionClass(\Composer\Autoload\ClassLoader::class))->getFileName();
```
The solution is to use class_exits first and skip the above execution.